### PR TITLE
Refactor `prune_local`

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ For a more detailed explanation of the impact of tuning key parameters please se
 | `data` | (numpy.ndarray) n_samples x n_features |
 | `true_label` | (numpy.ndarray) (optional)|
 | `dist_std_local` |  (optional, default = 2) local pruning threshold: the number of standard deviations above the mean minkowski distance between neighbors of a given node. the higher the parameter, the more edges are retained|
+| `do_prune_local` | (optional, default=None) Whether or not to do local pruning. If None (default),
+  set to ``False`` if the number of samples is > 300 000, and set to ``True`` otherwise.|
 | `jac_std_global` |  (optional, default = 'median') global level  graph pruning. This threshold can also be set as the number of standard deviations below the network's mean-jaccard-weighted edges. 0.1-1 provide reasonable pruning. higher value means less pruning. e.g. a value of 0.15 means all edges that are above mean(edgeweight)-0.15*std(edge-weights) are retained. We find both 0.15 and 'median' to yield good results resulting in pruning away ~ 50-60% edges |
 | `dist_std_local` |  (optional, default = 2) local pruning threshold: the number of standard deviations above the mean minkowski distance between neighbors of a given node. higher value means less pruning|
 | `random_seed` |  (optional, default = 42) The random seed to pass to Leiden|

--- a/docs/Parameter Usage.rst
+++ b/docs/Parameter Usage.rst
@@ -22,6 +22,10 @@ For a more detailed explanation of the impact of tuning key parameters please se
    * - l2_std_factor
      - (optional, default = 2) local pruning threshold: the higher the parameter, the more edges are retained
 
+   * - do_prune_local
+     - (optional, default=None) Whether or not to do local pruning. If ``None`` (default),
+       set to ``False`` if the number of samples is > 300 000, and set to ``True`` otherwise.
+
    * - jac_std_factor
      - (optional, default = 'median') global level  graph pruning. This threshold can also be set as the number of standard deviations below the network's mean-jaccard-weighted edges. 0.1-1 provide reasonable pruning. higher value means less pruning. e.g. a value of 0.15 means all edges that are above mean(edgeweight)-0.15*std(edge-weights) are retained. We find both 0.15 and 'median' to yield good results resulting in pruning away ~ 50-60% edges
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -316,12 +316,12 @@ class PARC:
             distance_array = distance_array + 0.1
             bar = Bar("Local pruning...", max=n_samples)
             for neighbors in neighbor_array:
-                distlist = distance_array[rowi, :]
+                distances = distance_array[rowi, :]
                 to_keep = np.where(
-                    distlist < np.mean(distlist) + self.l2_std_factor * np.std(distlist)
+                    distances < np.mean(distances) + self.l2_std_factor * np.std(distances)
                 )[0]  # 0*std
                 updated_nn_ind = neighbors[np.ix_(to_keep)]
-                updated_nn_weights = distlist[np.ix_(to_keep)]
+                updated_nn_weights = distances[np.ix_(to_keep)]
                 discard_count = discard_count + (n_neighbors - len(to_keep))
 
                 for ik in range(len(updated_nn_ind)):

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -325,16 +325,16 @@ class PARC:
                         row_list.append(sample_index)
                         col_list.append(updated_neighbors[index])
                         dist = np.sqrt(updated_distances[index])
-                        weight_list.append(1/(dist+0.1))
+                        weight_list.append(1 / (dist + 0.1))
 
                 bar.next()
             bar.finish()
         else:
             row_list.extend(
-                list(np.transpose(np.ones((n_neighbors, n_samples)) * range(0, n_samples)).flatten())
+                list(np.transpose(np.ones((n_neighbors, n_samples)) * range(n_samples)).flatten())
             )
             col_list = neighbor_array.flatten().tolist()
-            weight_list = (1. / (distance_array.flatten() + 0.1)).tolist()
+            weight_list = (1.0 / (distance_array.flatten() + 0.1)).tolist()
 
         csr_graph = csr_matrix((np.array(weight_list), (np.array(row_list), np.array(col_list))),
                                shape=(n_samples, n_samples))

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -297,7 +297,6 @@ class PARC:
 
         n_neighbors = neighbor_array.shape[1]
         n_samples = neighbor_array.shape[0]
-        rowi = 0
         discard_count = 0
 
         if self.keep_all_local_dist:  # dont prune based on distance
@@ -313,10 +312,11 @@ class PARC:
                 f"Starting local pruning based on Euclidean (L2) distance metric at "
                 f"{self.l2_std_factor} standard deviations above mean"
             )
+            sample_index = 0
             distance_array = distance_array + 0.1
             bar = Bar("Local pruning...", max=n_samples)
             for neighbors in neighbor_array:
-                distances = distance_array[rowi, :]
+                distances = distance_array[sample_index, :]
                 to_keep = np.where(
                     distances < np.mean(distances) + self.l2_std_factor * np.std(distances)
                 )[0]  # 0*std
@@ -325,13 +325,13 @@ class PARC:
                 discard_count = discard_count + (n_neighbors - len(to_keep))
 
                 for ik in range(len(updated_nn_ind)):
-                    if rowi != neighbors[ik]:  # remove self-loops
-                        row_list.append(rowi)
+                    if sample_index != neighbors[ik]:  # remove self-loops
+                        row_list.append(sample_index)
                         col_list.append(updated_nn_ind[ik])
                         dist = np.sqrt(updated_nn_weights[ik])
                         weight_list.append(1/(dist+0.1))
 
-                rowi = rowi + 1
+                sample_index = sample_index + 1
                 bar.next()
             bar.finish()
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -317,14 +317,14 @@ class PARC:
                 to_keep = np.where(
                     distances < np.mean(distances) + l2_std_factor * np.std(distances)
                 )[0]
-                updated_nn_ind = neighbors[np.ix_(to_keep)]
+                updated_neighbors = neighbors[np.ix_(to_keep)]
                 updated_nn_weights = distances[np.ix_(to_keep)]
                 discard_count = discard_count + (n_neighbors - len(to_keep))
 
-                for ik in range(len(updated_nn_ind)):
+                for ik in range(len(updated_neighbors)):
                     if sample_index != neighbors[ik]:
                         row_list.append(sample_index)
-                        col_list.append(updated_nn_ind[ik])
+                        col_list.append(updated_neighbors[ik])
                         dist = np.sqrt(updated_nn_weights[ik])
                         weight_list.append(1/(dist+0.1))
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -314,9 +314,8 @@ class PARC:
             bar = Bar("Local pruning...", max=n_samples)
             for sample_index, neighbors in zip(range(n_samples), neighbor_array):
                 distances = distance_array[sample_index, :]
-                to_keep = np.where(
-                    distances < np.mean(distances) + l2_std_factor * np.std(distances)
-                )[0]
+                max_distance = np.mean(distances) + l2_std_factor * np.std(distances)
+                to_keep = np.where(distances < max_distance)[0]
                 updated_neighbors = neighbors[np.ix_(to_keep)]
                 updated_distances = distances[np.ix_(to_keep)]
                 discard_count = discard_count + (n_neighbors - len(to_keep))

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -312,10 +312,9 @@ class PARC:
                 f"Starting local pruning based on Euclidean (L2) distance metric at "
                 f"{self.l2_std_factor} standard deviations above mean"
             )
-            sample_index = 0
             distance_array = distance_array + 0.1
             bar = Bar("Local pruning...", max=n_samples)
-            for neighbors in neighbor_array:
+            for sample_index, neighbors in zip(range(n_samples), neighbor_array):
                 distances = distance_array[sample_index, :]
                 to_keep = np.where(
                     distances < np.mean(distances) + self.l2_std_factor * np.std(distances)
@@ -331,7 +330,6 @@ class PARC:
                         dist = np.sqrt(updated_nn_weights[ik])
                         weight_list.append(1/(dist+0.1))
 
-                sample_index = sample_index + 1
                 bar.next()
             bar.finish()
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -315,17 +315,17 @@ class PARC:
             )
             distance_array = distance_array + 0.1
             bar = Bar("Local pruning...", max=n_samples)
-            for row in neighbor_array:
+            for neighbors in neighbor_array:
                 distlist = distance_array[rowi, :]
                 to_keep = np.where(
                     distlist < np.mean(distlist) + self.l2_std_factor * np.std(distlist)
                 )[0]  # 0*std
-                updated_nn_ind = row[np.ix_(to_keep)]
+                updated_nn_ind = neighbors[np.ix_(to_keep)]
                 updated_nn_weights = distlist[np.ix_(to_keep)]
                 discard_count = discard_count + (n_neighbors - len(to_keep))
 
                 for ik in range(len(updated_nn_ind)):
-                    if rowi != row[ik]:  # remove self-loops
+                    if rowi != neighbors[ik]:  # remove self-loops
                         row_list.append(rowi)
                         col_list.append(updated_nn_ind[ik])
                         dist = np.sqrt(updated_nn_weights[ik])

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -318,14 +318,14 @@ class PARC:
                     distances < np.mean(distances) + l2_std_factor * np.std(distances)
                 )[0]
                 updated_neighbors = neighbors[np.ix_(to_keep)]
-                updated_nn_weights = distances[np.ix_(to_keep)]
+                updated_distances = distances[np.ix_(to_keep)]
                 discard_count = discard_count + (n_neighbors - len(to_keep))
 
                 for ik in range(len(updated_neighbors)):
                     if sample_index != neighbors[ik]:
                         row_list.append(sample_index)
                         col_list.append(updated_neighbors[ik])
-                        dist = np.sqrt(updated_nn_weights[ik])
+                        dist = np.sqrt(updated_distances[ik])
                         weight_list.append(1/(dist+0.1))
 
                 bar.next()

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -19,7 +19,7 @@ class PARC:
     def __init__(self, x_data, y_data_true=None, knn=30, n_iter_leiden=5, random_seed=42,
                  distance_metric="l2", n_threads=-1, hnsw_param_ef_construction=150,
                  neighbor_graph=None, knn_struct=None,
-                 l2_std_factor=3, keep_all_local_dist=None,
+                 l2_std_factor=3.0, keep_all_local_dist=None,
                  jac_threshold_type="median", jac_std_factor=0.15, jac_weighted_edges=True,
                  resolution_parameter=1.0, partition_type="ModularityVP",
                  large_community_factor=0.4, small_community_size=10, small_community_timeout=15

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -321,11 +321,11 @@ class PARC:
                 updated_distances = distances[np.ix_(to_keep)]
                 discard_count = discard_count + (n_neighbors - len(to_keep))
 
-                for ik in range(len(updated_neighbors)):
-                    if sample_index != neighbors[ik]:
+                for index in range(len(updated_neighbors)):
+                    if sample_index != neighbors[index]:
                         row_list.append(sample_index)
-                        col_list.append(updated_neighbors[ik])
-                        dist = np.sqrt(updated_distances[ik])
+                        col_list.append(updated_neighbors[index])
+                        dist = np.sqrt(updated_distances[index])
                         weight_list.append(1/(dist+0.1))
 
                 bar.next()


### PR DESCRIPTION
# Description

In this PR, I renamed some variables in the `prune_local` function, notably `keep_all_local_dist` is now `do_prune_local`, where:

```python
keep_all_local_dist = not do_prune_local
```