### PR TITLE
`func_mode` -> `get_mode`

### DIFF
--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -6,6 +6,7 @@ import igraph as ig
 import leidenalg
 import time
 from umap.umap_ import find_ab_params, simplicial_set_embedding
+from parc.utils import get_mode
 from parc.logger import get_logger
 
 
@@ -192,10 +193,6 @@ class PARC:
             shape=(n_cells, n_cells)
         )
         return csr_graph
-
-    def func_mode(self, ll):  # return MODE of list
-        # If multiple items are maximal, the function returns the first one encountered.
-        return max(set(ll), key=ll.count)
 
     def run_toobig_subPARC(
         self,
@@ -551,7 +548,7 @@ class PARC:
 
         for kk in sorted_keys:
             vals = [t for t in Index_dict[kk]]
-            majority_val = self.func_mode(vals)
+            majority_val = get_mode(vals)
             if majority_val == onevsall:
                 logger.message(f"Cluster {kk} has majority {onevsall} with population {len(vals)}")
             if kk == -1:
@@ -596,7 +593,7 @@ class PARC:
         for cluster_i in set(PARC_labels):
             cluster_i_loc = np.where(np.asarray(PARC_labels) == cluster_i)[0]
             true_labels = np.asarray(true_labels)
-            majority_truth = self.func_mode(list(true_labels[cluster_i_loc]))
+            majority_truth = get_mode(list(true_labels[cluster_i_loc]))
             majority_truth_labels[cluster_i_loc] = majority_truth
 
         majority_truth_labels = list(majority_truth_labels.flatten())

--- a/parc/utils.py
+++ b/parc/utils.py
@@ -1,7 +1,8 @@
 def get_mode(a_list: list[any]) -> any:
     """Get the value which appears most often in the list (the mode).
 
-    If multiple items are maximal, the function returns the first one encountered.
+    If multiple items are maximal, the function returns the first one encountered
+    (not necessarily the first one in the list).
 
     Args:
         a_list: A list with values.

--- a/parc/utils.py
+++ b/parc/utils.py
@@ -1,0 +1,12 @@
+def get_mode(a_list: list[any]) -> any:
+    """Get the value which appears most often in the list (the mode).
+
+    If multiple items are maximal, the function returns the first one encountered.
+
+    Args:
+        a_list: A list with values.
+
+    Returns:
+        The most frequent value in the list
+    """
+    return max(set(a_list), key=a_list.count)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import pytest
+from parc.utils import get_mode
+
+
+@pytest.mark.parametrize(
+    "input_list, expected_mode",
+    [
+        ([1, 2, 3, 4, 5], [1, 2, 3, 4, 5]),
+        ([1, 2, 3, 4, 2, 6], [2]),
+        (["a", "b", "c", "d", "e", "a", "b", "c"], ["a", "b", "c"])
+    ]
+)
+def test_get_mode(input_list, expected_mode):
+    assert get_mode(input_list) in expected_mode


### PR DESCRIPTION
# Description

In this PR, I have moved `func_mode` out of the `PARC` class since it doesn't belong there, and put it in
`utils.py`. I have also renamed it `get_mode`, and added docstrings and tests.

See https://github.com/ShobiStassen/PARC/pull/31.