### PR TITLE
Rename variables

### DIFF
--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -468,12 +468,12 @@ class PARC:
                         f"Cluster {community_id} is too big and has population {community_size}."
                     )
                     large_community_indices = community_indices
-                    cluster_big = community_id
+                    large_community_id = community_id
                     big_pop = community_size
             if too_big:
                 list_pop_too_bigs.append(big_pop)
                 logger.message(
-                    f"Cluster {cluster_big} is too big and has population {big_pop}."
+                    f"Cluster {large_community_id} is too big and has population {big_pop}."
                     "It will be expanded."
                 )
         node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -28,7 +28,7 @@ class PARC:
         n_iter_leiden=5,
         random_seed=42,
         n_threads=-1,
-        distance="l2",
+        distance_metric="l2",
         small_community_timeout=15,
         partition_type="ModularityVP",
         resolution_parameter=1.0,
@@ -57,7 +57,7 @@ class PARC:
         self.n_iter_leiden = n_iter_leiden #the default is 5 in PARC
         self.random_seed = random_seed  # enable reproducible Leiden clustering
         self.n_threads = n_threads  # number of threads used in KNN search/construction
-        self.distance = distance  # Euclidean distance "l2" by default; other options "ip" and "cosine"
+        self.distance_metric = distance_metric  # Euclidean distance "l2" by default; other options "ip" and "cosine"
         self.small_community_timeout = small_community_timeout #number of seconds trying to check an outlier
         self.partition_type = partition_type #default is the simple ModularityVertexPartition where resolution_parameter =1. In order to change resolution_parameter, we switch to RBConfigurationVP
         self.resolution_parameter = resolution_parameter # defaults to 1. expose this parameter in leidenalg
@@ -74,7 +74,7 @@ class PARC:
         if not too_big:
             num_dims = self.x_data.shape[1]
             n_samples = self.x_data.shape[0]
-            p = hnswlib.Index(space=self.distance, dim=num_dims)  # default to Euclidean distance
+            p = hnswlib.Index(space=self.distance_metric, dim=num_dims)  # default to Euclidean distance
             p.set_num_threads(self.n_threads)  # set threads used in KNN construction
             if n_samples < 10000:
                 ef_query = min(n_samples - 10, 500)

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -434,9 +434,9 @@ class PARC:
             list_pop_too_bigs = [community_size]
 
         while too_big:
-
-            X_data_big = x_data[large_community_indices, :]
-            node_communities_big = self.run_toobig_subPARC(X_data_big)
+            node_communities_big = self.run_toobig_subPARC(
+                x_data=x_data[large_community_indices, :]
+            )
             node_communities_big = node_communities_big + 100000
             pop_list = []
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -285,12 +285,12 @@ class PARC:
         PARC_labels_leiden = np.reshape(PARC_labels_leiden, (n_samples, 1))
         small_pop_list = []
         small_cluster_list = []
-        small_pop_exist = False
+        small_community_exists = False
         PARC_labels_leiden = np.unique(list(PARC_labels_leiden.flatten()), return_inverse=True)[1]
         for cluster in set(PARC_labels_leiden):
             population = len(np.where(PARC_labels_leiden == cluster)[0])
             if population < small_community_size:
-                small_pop_exist = True
+                small_community_exists = True
                 small_pop_list.append(list(np.where(PARC_labels_leiden == cluster)[0]))
                 small_cluster_list.append(cluster)
 
@@ -308,13 +308,13 @@ class PARC:
 
         time_start = time.time()
         logger.message("Handling fragments...")
-        while small_pop_exist & (time.time() - time_start < self.small_community_timeout):
+        while small_community_exists & (time.time() - time_start < self.small_community_timeout):
             small_pop_list = []
-            small_pop_exist = False
+            small_community_exists = False
             for cluster in set(list(PARC_labels_leiden.flatten())):
                 population = len(np.where(PARC_labels_leiden == cluster)[0])
                 if population < small_community_size:
-                    small_pop_exist = True
+                    small_community_exists = True
 
                     small_pop_list.append(np.where(PARC_labels_leiden == cluster)[0])
             for small_cluster in small_pop_list:
@@ -477,13 +477,13 @@ class PARC:
         PARC_labels_leiden = np.unique(list(PARC_labels_leiden.flatten()), return_inverse=True)[1]
         small_pop_list = []
         small_cluster_list = []
-        small_pop_exist = False
+        small_community_exists = False
 
         for cluster in set(PARC_labels_leiden):
             population = len(np.where(PARC_labels_leiden == cluster)[0])
 
             if population < small_community_size:  # 10
-                small_pop_exist = True
+                small_community_exists = True
 
                 small_pop_list.append(list(np.where(PARC_labels_leiden == cluster)[0]))
                 small_cluster_list.append(cluster)
@@ -501,13 +501,13 @@ class PARC:
                     best_group = max(available_neighbours_list, key=available_neighbours_list.count)
                     PARC_labels_leiden[single_cell] = best_group
         time_start = time.time()
-        while small_pop_exist & ((time.time() - time_start) < self.small_community_timeout):
+        while small_community_exists & ((time.time() - time_start) < self.small_community_timeout):
             small_pop_list = []
-            small_pop_exist = False
+            small_community_exists = False
             for cluster in set(list(PARC_labels_leiden.flatten())):
                 population = len(np.where(PARC_labels_leiden == cluster)[0])
                 if population < small_community_size:
-                    small_pop_exist = True
+                    small_community_exists = True
                     logger.message(f"Cluster {cluster} has small population of {population}.")
                     small_pop_list.append(np.where(PARC_labels_leiden == cluster)[0])
             for small_cluster in small_pop_list:

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -426,11 +426,11 @@ class PARC:
 
         # The 0th cluster is the largest one.
         # So, if cluster 0 is not too big, then the others won't be too big either
-        cluster_i_loc = np.where(node_communities == 0)[0]
-        community_size = len(cluster_i_loc)
+        community_indices = np.where(node_communities == 0)[0]
+        community_size = len(community_indices)
         if community_size > large_community_factor * n_samples:  # 0.4
             too_big = True
-            cluster_big_loc = cluster_i_loc
+            cluster_big_loc = community_indices
             list_pop_too_bigs = [community_size]
 
         while too_big:
@@ -459,15 +459,15 @@ class PARC:
 
             node_communities = np.asarray(node_communities)
             for community_id in set_node_communities:
-                cluster_ii_loc = np.where(node_communities == community_id)[0]
-                community_size = len(cluster_ii_loc)
+                community_indices = np.where(node_communities == community_id)[0]
+                community_size = len(community_indices)
                 not_yet_expanded = community_size not in list_pop_too_bigs
                 if community_size > large_community_factor * n_samples and not_yet_expanded:
                     too_big = True
                     logger.message(
                         f"Cluster {community_id} is too big and has population {community_size}."
                     )
-                    cluster_big_loc = cluster_ii_loc
+                    cluster_big_loc = community_indices
                     cluster_big = community_id
                     big_pop = community_size
             if too_big:
@@ -593,10 +593,10 @@ class PARC:
         majority_truth_labels = np.empty((len(y_data_true), 1), dtype=object)
 
         for cluster_i in set(y_data_pred):
-            cluster_i_loc = np.where(np.asarray(y_data_pred) == cluster_i)[0]
+            community_indices = np.where(np.asarray(y_data_pred) == cluster_i)[0]
             y_data_true = np.asarray(y_data_true)
-            majority_truth = get_mode(list(y_data_true[cluster_i_loc]))
-            majority_truth_labels[cluster_i_loc] = majority_truth
+            majority_truth = get_mode(list(y_data_true[community_indices]))
+            majority_truth_labels[community_indices] = majority_truth
 
         majority_truth_labels = list(majority_truth_labels.flatten())
         accuracy_val = [error_rate, f1_score, tnr, fnr, tpr, fpr, precision,

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -214,9 +214,9 @@ class PARC:
         csr_array = self.make_csrmatrix_noselfloop(neighbor_array, distance_array)
         sources, targets = csr_array.nonzero()
 
-        edgelist = list(zip(sources.tolist(), targets.tolist()))
-        edgelist_copy = edgelist.copy()
-        graph = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
+        edges = list(zip(sources.tolist(), targets.tolist()))
+        edgelist_copy = edges.copy()
+        graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
         similarities = graph.similarity_jaccard(pairs=edgelist_copy)  # list of jaccard weights
         new_edgelist = []
         similarities_array = np.asarray(similarities)
@@ -353,11 +353,11 @@ class PARC:
 
         sources, targets = csr_array.nonzero()
 
-        edgelist = list(zip(sources, targets))
+        edges = list(zip(sources, targets))
 
-        edgelist_copy = edgelist.copy()
+        edgelist_copy = edges.copy()
 
-        graph = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
+        graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
         similarities = graph.similarity_jaccard(pairs=edgelist_copy)
 
         logger.message("Starting global pruning...")

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -525,20 +525,20 @@ class PARC:
             pop_list.append((item, PARC_labels_leiden.count(item)))
         logger.message(f"Cluster labels and populations {len(pop_list)} {pop_list}")
 
-        self.labels = PARC_labels_leiden
+        self.y_data_pred = PARC_labels_leiden
         return
 
     def accuracy(self, onevsall=1):
 
         y_data_true = self.y_data_true
         Index_dict = {}
-        PARC_labels = self.labels
-        N = len(PARC_labels)
+        y_data_pred = self.y_data_pred
+        N = len(y_data_pred)
         n_cancer = list(y_data_true).count(onevsall)
         n_pbmc = N - n_cancer
 
         for k in range(N):
-            Index_dict.setdefault(PARC_labels[k], []).append(y_data_true[k])
+            Index_dict.setdefault(y_data_pred[k], []).append(y_data_true[k])
         num_groups = len(Index_dict)
         sorted_keys = list(sorted(Index_dict.keys()))
         error_count = []
@@ -567,8 +567,8 @@ class PARC:
                 fn = fn + len([e for e in vals if e == onevsall])
                 error_count.append(len([e for e in vals if e != majority_val]))
 
-        predict_class_array = np.array(PARC_labels)
-        PARC_labels_array = np.array(PARC_labels)
+        predict_class_array = np.array(y_data_pred)
+        PARC_labels_array = np.array(y_data_pred)
         number_clusters_for_target = len(thp1_labels)
         for cancer_class in thp1_labels:
             predict_class_array[PARC_labels_array == cancer_class] = 1
@@ -590,8 +590,8 @@ class PARC:
             f1_score = precision * recall * 2 / (precision + recall)
         majority_truth_labels = np.empty((len(y_data_true), 1), dtype=object)
 
-        for cluster_i in set(PARC_labels):
-            cluster_i_loc = np.where(np.asarray(PARC_labels) == cluster_i)[0]
+        for cluster_i in set(y_data_pred):
+            cluster_i_loc = np.where(np.asarray(y_data_pred) == cluster_i)[0]
             y_data_true = np.asarray(y_data_true)
             majority_truth = get_mode(list(y_data_true[cluster_i_loc]))
             majority_truth_labels[cluster_i_loc] = majority_truth

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -427,11 +427,11 @@ class PARC:
         # The 0th cluster is the largest one.
         # So, if cluster 0 is not too big, then the others won't be too big either
         cluster_i_loc = np.where(node_communities == 0)[0]
-        pop_i = len(cluster_i_loc)
-        if pop_i > large_community_factor * n_samples:  # 0.4
+        community_size = len(cluster_i_loc)
+        if community_size > large_community_factor * n_samples:  # 0.4
             too_big = True
             cluster_big_loc = cluster_i_loc
-            list_pop_too_bigs = [pop_i]
+            list_pop_too_bigs = [community_size]
 
         while too_big:
 
@@ -460,14 +460,16 @@ class PARC:
             node_communities = np.asarray(node_communities)
             for community_id in set_node_communities:
                 cluster_ii_loc = np.where(node_communities == community_id)[0]
-                pop_ii = len(cluster_ii_loc)
-                not_yet_expanded = pop_ii not in list_pop_too_bigs
-                if pop_ii > large_community_factor * n_samples and not_yet_expanded:
+                community_size = len(cluster_ii_loc)
+                not_yet_expanded = community_size not in list_pop_too_bigs
+                if community_size > large_community_factor * n_samples and not_yet_expanded:
                     too_big = True
-                    logger.message(f"Cluster {community_id} is too big and has population {pop_ii}.")
+                    logger.message(
+                        f"Cluster {community_id} is too big and has population {community_size}."
+                    )
                     cluster_big_loc = cluster_ii_loc
                     cluster_big = community_id
-                    big_pop = pop_ii
+                    big_pop = community_size
             if too_big:
                 list_pop_too_bigs.append(big_pop)
                 logger.message(

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -458,15 +458,15 @@ class PARC:
             logger.message(f"New set of labels {set_node_communities}")
 
             node_communities = np.asarray(node_communities)
-            for cluster_ii in set_node_communities:
-                cluster_ii_loc = np.where(node_communities == cluster_ii)[0]
+            for community_id in set_node_communities:
+                cluster_ii_loc = np.where(node_communities == community_id)[0]
                 pop_ii = len(cluster_ii_loc)
                 not_yet_expanded = pop_ii not in list_pop_too_bigs
                 if pop_ii > large_community_factor * n_samples and not_yet_expanded:
                     too_big = True
-                    logger.message(f"Cluster {cluster_ii} is too big and has population {pop_ii}.")
+                    logger.message(f"Cluster {community_id} is too big and has population {pop_ii}.")
                     cluster_big_loc = cluster_ii_loc
-                    cluster_big = cluster_ii
+                    cluster_big = community_id
                     big_pop = pop_ii
             if too_big:
                 list_pop_too_bigs.append(big_pop)

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -212,9 +212,9 @@ class PARC:
 
         neighbor_array, distance_array = hnsw.knn_query(x_data, k=knnbig)
         csr_array = self.make_csrmatrix_noselfloop(neighbor_array, distance_array)
-        input_nodes, targets = csr_array.nonzero()
+        input_nodes, output_nodes = csr_array.nonzero()
 
-        edges = list(zip(input_nodes.tolist(), targets.tolist()))
+        edges = list(zip(input_nodes.tolist(), output_nodes.tolist()))
         edges_copy = edges.copy()
         graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
         similarities = graph.similarity_jaccard(pairs=edges_copy)  # list of jaccard weights
@@ -351,9 +351,9 @@ class PARC:
             neighbor_array, distance_array = self.knn_struct.knn_query(x_data, k=knn)
             csr_array = self.make_csrmatrix_noselfloop(neighbor_array, distance_array)
 
-        input_nodes, targets = csr_array.nonzero()
+        input_nodes, output_nodes = csr_array.nonzero()
 
-        edges = list(zip(input_nodes, targets))
+        edges = list(zip(input_nodes, output_nodes))
 
         edges_copy = edges.copy()
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -212,9 +212,9 @@ class PARC:
 
         neighbor_array, distance_array = hnsw.knn_query(x_data, k=knnbig)
         csr_array = self.make_csrmatrix_noselfloop(neighbor_array, distance_array)
-        sources, targets = csr_array.nonzero()
+        input_nodes, targets = csr_array.nonzero()
 
-        edges = list(zip(sources.tolist(), targets.tolist()))
+        edges = list(zip(input_nodes.tolist(), targets.tolist()))
         edges_copy = edges.copy()
         graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
         similarities = graph.similarity_jaccard(pairs=edges_copy)  # list of jaccard weights
@@ -351,9 +351,9 @@ class PARC:
             neighbor_array, distance_array = self.knn_struct.knn_query(x_data, k=knn)
             csr_array = self.make_csrmatrix_noselfloop(neighbor_array, distance_array)
 
-        sources, targets = csr_array.nonzero()
+        input_nodes, targets = csr_array.nonzero()
 
-        edges = list(zip(sources, targets))
+        edges = list(zip(input_nodes, targets))
 
         edges_copy = edges.copy()
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -544,7 +544,7 @@ class PARC:
         num_groups = len(Index_dict)
         sorted_keys = list(sorted(Index_dict.keys()))
         error_count = []
-        pbmc_labels = []
+        negative_labels = []
         thp1_labels = []
         fp, fn, tp, tn, precision, recall, f1_score = 0, 0, 0, 0, 0, 0, 0
 
@@ -564,7 +564,7 @@ class PARC:
                 e_count = len(list_error)
                 error_count.append(e_count)
             elif (majority_val != onevsall) and (kk != -1):
-                pbmc_labels.append(kk)
+                negative_labels.append(kk)
                 tn = tn + len([e for e in vals if e != onevsall])
                 fn = fn + len([e for e in vals if e == onevsall])
                 error_count.append(len([e for e in vals if e != majority_val]))
@@ -574,7 +574,7 @@ class PARC:
         number_clusters_for_target = len(thp1_labels)
         for cancer_class in thp1_labels:
             predict_class_array[y_data_pred_array == cancer_class] = 1
-        for benign_class in pbmc_labels:
+        for benign_class in negative_labels:
             predict_class_array[y_data_pred_array == benign_class] = 0
         predict_class_array.reshape((predict_class_array.shape[0], -1))
         error_rate = sum(error_count) / n_samples

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -363,14 +363,13 @@ class PARC:
         logger.message("Starting global pruning...")
 
         similarities_array = np.asarray(similarities)
-        edge_list_copy_array = np.asarray(edges_copy)
 
         if jac_std_factor == "median":
             threshold = np.median(similarities)
         else:
             threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
         strong_locs = np.where(similarities_array > threshold)[0]
-        new_edges = list(edge_list_copy_array[strong_locs])
+        new_edges = list(np.asarray(edges_copy)[strong_locs])
         similarities_new = list(similarities_array[strong_locs])
 
         graph_pruned = ig.Graph(

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -545,7 +545,7 @@ class PARC:
         sorted_keys = list(sorted(Index_dict.keys()))
         error_count = []
         negative_labels = []
-        thp1_labels = []
+        positive_labels = []
         fp, fn, tp, tn, precision, recall, f1_score = 0, 0, 0, 0, 0, 0, 0
 
         for kk in sorted_keys:
@@ -557,7 +557,7 @@ class PARC:
                 len_unknown = len(vals)
                 logger.message(f"len unknown: {len_unknown}")
             if (majority_val == onevsall) and (kk != -1):
-                thp1_labels.append(kk)
+                positive_labels.append(kk)
                 fp = fp + len([e for e in vals if e != onevsall])
                 tp = tp + len([e for e in vals if e == onevsall])
                 list_error = [e for e in vals if e != majority_val]
@@ -571,8 +571,8 @@ class PARC:
 
         predict_class_array = np.array(y_data_pred)
         y_data_pred_array = np.array(y_data_pred)
-        number_clusters_for_target = len(thp1_labels)
-        for cancer_class in thp1_labels:
+        number_clusters_for_target = len(positive_labels)
+        for cancer_class in positive_labels:
             predict_class_array[y_data_pred_array == cancer_class] = 1
         for benign_class in negative_labels:
             predict_class_array[y_data_pred_array == benign_class] = 0

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -18,7 +18,7 @@ class PARC:
         self,
         x_data,
         y_data_true=None,
-        dist_std_local=3,
+        l2_std_factor=3,
         jac_std_global="median",
         keep_all_local_dist="auto",
         large_community_factor=0.4,
@@ -36,7 +36,7 @@ class PARC:
         neighbor_graph=None,
         hnsw_param_ef_construction=150
     ):
-        # higher dist_std_local means more edges are kept
+        # higher l2_std_factor means more edges are kept
         # highter jac_std_global means more edges are kept
         if keep_all_local_dist == "auto":
             if x_data.shape[0] > 300000:
@@ -47,7 +47,7 @@ class PARC:
             partition_type = "RBVP" # Reichardt and Bornholdt’s Potts model. Note that this is the same as ModularityVertexPartition when setting 𝛾 = 1 and normalising by 2m
         self.x_data = x_data
         self.y_data_true = y_data_true
-        self.dist_std_local = dist_std_local   # similar to the jac_std_global parameter. avoid setting local and global pruning to both be below 0.5 as this is very aggresive pruning.
+        self.l2_std_factor = l2_std_factor   # similar to the jac_std_global parameter. avoid setting local and global pruning to both be below 0.5 as this is very aggresive pruning.
         self.jac_std_global = jac_std_global  #0.15 is also a recommended value performing empirically similar to "median". Generally values between 0-1.5 are reasonable.
         self.keep_all_local_dist = keep_all_local_dist #decides whether or not to do local pruning. default is "auto" which omits LOCAL pruning for samples >300,000 cells.
         self.large_community_factor = large_community_factor  #if a cluster exceeds this share of the entire cell population, then the PARC will be run on the large cluster. at 0.4 it does not come into play
@@ -160,13 +160,13 @@ class PARC:
 
             logger.message(
                 "Starting local pruning based on Euclidean distance metric at "
-                f"{self.dist_std_local} standard deviations above the mean"
+                f"{self.l2_std_factor} standard deviations above the mean"
             )
             distance_array = distance_array + 0.1
             for row in neighbor_array:
                 distlist = distance_array[rowi, :]
                 to_keep = np.where(
-                    distlist < np.mean(distlist) + self.dist_std_local * np.std(distlist)
+                    distlist < np.mean(distlist) + self.l2_std_factor * np.std(distlist)
                 )[0]  # 0 * std
                 updated_nn_ind = row[np.ix_(to_keep)]
                 updated_nn_weights = distlist[np.ix_(to_keep)]
@@ -623,7 +623,7 @@ class PARC:
         self.f1_mean = 0
         self.stats_df = pd.DataFrame({
             "jac_std_global": [self.jac_std_global],
-            "dist_std_local": [self.dist_std_local],
+            "l2_std_factor": [self.l2_std_factor],
             "runtime(s)": [run_time]
         })
         self.majority_truth_labels = []
@@ -641,7 +641,7 @@ class PARC:
                 f1_acc_noweighting = f1_acc_noweighting + f1_current
 
                 list_roc.append(
-                    [self.jac_std_global, self.dist_std_local, onevsall_val] +
+                    [self.jac_std_global, self.l2_std_factor, onevsall_val] +
                     vals_roc +
                     [numclusters_targetval] +
                     [run_time]
@@ -654,7 +654,7 @@ class PARC:
             df_accuracy = pd.DataFrame(
                 list_roc,
                 columns=[
-                    "jac_std_global", "dist_std_local", "onevsall-target", "error rate",
+                    "jac_std_global", "l2_std_factor", "onevsall-target", "error rate",
                     "f1-score", "tnr", "fnr", "tpr", "fpr", "precision", "recall", "num_groups",
                     "population of target", "num clusters", "clustering runtime"
                 ]

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -536,8 +536,8 @@ class PARC:
         Index_dict = {}
         y_data_pred = self.y_data_pred
         n_samples = len(y_data_pred)
-        n_cancer = list(y_data_true).count(onevsall)
-        n_pbmc = n_samples - n_cancer
+        n_target = list(y_data_true).count(onevsall)
+        n_pbmc = n_samples - n_target
 
         for k in range(n_samples):
             Index_dict.setdefault(y_data_pred[k], []).append(y_data_true[k])
@@ -580,8 +580,8 @@ class PARC:
         error_rate = sum(error_count) / n_samples
         n_target = tp + fn
         tnr = tn / n_pbmc
-        fnr = fn / n_cancer
-        tpr = tp / n_cancer
+        fnr = fn / n_target
+        tpr = tp / n_target
         fpr = fp / n_pbmc
 
         if tp != 0 or fn != 0:

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -217,17 +217,17 @@ class PARC:
         edgelist = list(zip(sources.tolist(), targets.tolist()))
         edgelist_copy = edgelist.copy()
         graph = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
-        sim_list = graph.similarity_jaccard(pairs=edgelist_copy)  # list of jaccard weights
+        similarities = graph.similarity_jaccard(pairs=edgelist_copy)  # list of jaccard weights
         new_edgelist = []
-        sim_list_array = np.asarray(sim_list)
+        sim_list_array = np.asarray(similarities)
         if jac_std_factor == "median":
-            threshold = np.median(sim_list)
+            threshold = np.median(similarities)
         else:
-            threshold = np.mean(sim_list) - jac_std_factor * np.std(sim_list)
+            threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
 
         logger.message(f"jac threshold {threshold:.3f}")
-        logger.message(f"jac std {np.std(sim_list):.3f}")
-        logger.message(f"jac mean {np.mean(sim_list):.3f}")
+        logger.message(f"jac std {np.std(similarities):.3f}")
+        logger.message(f"jac mean {np.mean(similarities):.3f}")
 
         strong_locs = np.where(sim_list_array > threshold)[0]
         for ii in strong_locs:
@@ -358,17 +358,17 @@ class PARC:
         edgelist_copy = edgelist.copy()
 
         graph = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
-        sim_list = graph.similarity_jaccard(pairs=edgelist_copy)
+        similarities = graph.similarity_jaccard(pairs=edgelist_copy)
 
         logger.message("Starting global pruning...")
 
-        sim_list_array = np.asarray(sim_list)
+        sim_list_array = np.asarray(similarities)
         edge_list_copy_array = np.asarray(edgelist_copy)
 
         if jac_std_factor == "median":
-            threshold = np.median(sim_list)
+            threshold = np.median(similarities)
         else:
-            threshold = np.mean(sim_list) - jac_std_factor * np.std(sim_list)
+            threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
         strong_locs = np.where(sim_list_array > threshold)[0]
         new_edgelist = list(edge_list_copy_array[strong_locs])
         sim_list_new = list(sim_list_array[strong_locs])

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -592,8 +592,8 @@ class PARC:
             f1_score = precision * recall * 2 / (precision + recall)
         majority_truth_labels = np.empty((len(y_data_true), 1), dtype=object)
 
-        for cluster_i in set(y_data_pred):
-            community_indices = np.where(np.asarray(y_data_pred) == cluster_i)[0]
+        for community_id in set(y_data_pred):
+            community_indices = np.where(np.asarray(y_data_pred) == community_id)[0]
             y_data_true = np.asarray(y_data_true)
             majority_truth = get_mode(list(y_data_true[community_indices]))
             majority_truth_labels[community_indices] = majority_truth

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -216,8 +216,8 @@ class PARC:
 
         edgelist = list(zip(sources.tolist(), targets.tolist()))
         edgelist_copy = edgelist.copy()
-        G = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
-        sim_list = G.similarity_jaccard(pairs=edgelist_copy)  # list of jaccard weights
+        graph = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
+        sim_list = graph.similarity_jaccard(pairs=edgelist_copy)  # list of jaccard weights
         new_edgelist = []
         sim_list_array = np.asarray(sim_list)
         if jac_std_factor == "median":
@@ -357,8 +357,8 @@ class PARC:
 
         edgelist_copy = edgelist.copy()
 
-        G = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
-        sim_list = G.similarity_jaccard(pairs=edgelist_copy)
+        graph = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
+        sim_list = graph.similarity_jaccard(pairs=edgelist_copy)
 
         logger.message("Starting global pruning...")
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -281,53 +281,53 @@ class PARC:
                     seed=self.random_seed,
                     resolution_parameter=self.resolution_parameter
                 )
-        PARC_labels_leiden = np.asarray(partition.membership)
-        PARC_labels_leiden = np.reshape(PARC_labels_leiden, (n_samples, 1))
+        node_communities = np.asarray(partition.membership)
+        node_communities = np.reshape(node_communities, (n_samples, 1))
         small_pop_list = []
         small_cluster_list = []
         small_community_exists = False
-        PARC_labels_leiden = np.unique(list(PARC_labels_leiden.flatten()), return_inverse=True)[1]
-        for cluster in set(PARC_labels_leiden):
-            population = len(np.where(PARC_labels_leiden == cluster)[0])
+        node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]
+        for cluster in set(node_communities):
+            population = len(np.where(node_communities == cluster)[0])
             if population < small_community_size:
                 small_community_exists = True
-                small_pop_list.append(list(np.where(PARC_labels_leiden == cluster)[0]))
+                small_pop_list.append(list(np.where(node_communities == cluster)[0]))
                 small_cluster_list.append(cluster)
 
         for small_cluster in small_pop_list:
             for single_cell in small_cluster:
                 old_neighbors = neighbor_array[single_cell, :]
-                group_of_old_neighbors = PARC_labels_leiden[old_neighbors]
+                group_of_old_neighbors = node_communities[old_neighbors]
                 group_of_old_neighbors = list(group_of_old_neighbors.flatten())
                 available_neighbours = set(group_of_old_neighbors) - set(small_cluster_list)
                 if len(available_neighbours) > 0:
                     available_neighbours_list = [value for value in group_of_old_neighbors if
                                                  value in list(available_neighbours)]
                     best_group = max(available_neighbours_list, key=available_neighbours_list.count)
-                    PARC_labels_leiden[single_cell] = best_group
+                    node_communities[single_cell] = best_group
 
         time_start = time.time()
         logger.message("Handling fragments...")
         while small_community_exists & (time.time() - time_start < self.small_community_timeout):
             small_pop_list = []
             small_community_exists = False
-            for cluster in set(list(PARC_labels_leiden.flatten())):
-                population = len(np.where(PARC_labels_leiden == cluster)[0])
+            for cluster in set(list(node_communities.flatten())):
+                population = len(np.where(node_communities == cluster)[0])
                 if population < small_community_size:
                     small_community_exists = True
 
-                    small_pop_list.append(np.where(PARC_labels_leiden == cluster)[0])
+                    small_pop_list.append(np.where(node_communities == cluster)[0])
             for small_cluster in small_pop_list:
                 for single_cell in small_cluster:
                     old_neighbors = neighbor_array[single_cell, :]
-                    group_of_old_neighbors = PARC_labels_leiden[old_neighbors]
+                    group_of_old_neighbors = node_communities[old_neighbors]
                     group_of_old_neighbors = list(group_of_old_neighbors.flatten())
                     best_group = max(set(group_of_old_neighbors), key=group_of_old_neighbors.count)
-                    PARC_labels_leiden[single_cell] = best_group
+                    node_communities[single_cell] = best_group
 
-        PARC_labels_leiden = np.unique(list(PARC_labels_leiden.flatten()), return_inverse=True)[1]
+        node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]
 
-        return PARC_labels_leiden
+        return node_communities
 
     def run_subPARC(self):
 
@@ -419,14 +419,14 @@ class PARC:
                     resolution_parameter=self.resolution_parameter
                 )
 
-        PARC_labels_leiden = np.asarray(partition.membership)
-        PARC_labels_leiden = np.reshape(PARC_labels_leiden, (n_samples, 1))
+        node_communities = np.asarray(partition.membership)
+        node_communities = np.reshape(node_communities, (n_samples, 1))
 
         too_big = False
 
         # The 0th cluster is the largest one.
         # So, if cluster 0 is not too big, then the others won't be too big either
-        cluster_i_loc = np.where(PARC_labels_leiden == 0)[0]
+        cluster_i_loc = np.where(node_communities == 0)[0]
         pop_i = len(cluster_i_loc)
         if pop_i > large_community_factor * n_samples:  # 0.4
             too_big = True
@@ -445,20 +445,20 @@ class PARC:
 
             logger.message(f"pop of big clusters {pop_list}")
             jj = 0
-            logger.message(f"shape PARC_labels_leiden {PARC_labels_leiden.shape}")
+            logger.message(f"shape node_communities {node_communities.shape}")
             for j in cluster_big_loc:
-                PARC_labels_leiden[j] = PARC_labels_leiden_big[jj]
+                node_communities[j] = PARC_labels_leiden_big[jj]
                 jj = jj + 1
-            PARC_labels_leiden = np.unique(
-                list(PARC_labels_leiden.flatten()), return_inverse=True
+            node_communities = np.unique(
+                list(node_communities.flatten()), return_inverse=True
             )[1]
-            logger.message(f"New set of labels {set(PARC_labels_leiden)}")
+            logger.message(f"New set of labels {set(node_communities)}")
             too_big = False
-            set_PARC_labels_leiden = set(PARC_labels_leiden)
+            set_PARC_labels_leiden = set(node_communities)
 
-            PARC_labels_leiden = np.asarray(PARC_labels_leiden)
+            node_communities = np.asarray(node_communities)
             for cluster_ii in set_PARC_labels_leiden:
-                cluster_ii_loc = np.where(PARC_labels_leiden == cluster_ii)[0]
+                cluster_ii_loc = np.where(node_communities == cluster_ii)[0]
                 pop_ii = len(cluster_ii_loc)
                 not_yet_expanded = pop_ii not in list_pop_too_bigs
                 if pop_ii > large_community_factor * n_samples and not_yet_expanded:
@@ -473,58 +473,58 @@ class PARC:
                     f"Cluster {cluster_big} is too big and has population {big_pop}."
                     "It will be expanded."
                 )
-        PARC_labels_leiden = np.unique(list(PARC_labels_leiden.flatten()), return_inverse=True)[1]
+        node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]
         small_pop_list = []
         small_cluster_list = []
         small_community_exists = False
 
-        for cluster in set(PARC_labels_leiden):
-            population = len(np.where(PARC_labels_leiden == cluster)[0])
+        for cluster in set(node_communities):
+            population = len(np.where(node_communities == cluster)[0])
 
             if population < small_community_size:  # 10
                 small_community_exists = True
 
-                small_pop_list.append(list(np.where(PARC_labels_leiden == cluster)[0]))
+                small_pop_list.append(list(np.where(node_communities == cluster)[0]))
                 small_cluster_list.append(cluster)
 
         for small_cluster in small_pop_list:
 
             for single_cell in small_cluster:
                 old_neighbors = neighbor_array[single_cell]
-                group_of_old_neighbors = PARC_labels_leiden[old_neighbors]
+                group_of_old_neighbors = node_communities[old_neighbors]
                 group_of_old_neighbors = list(group_of_old_neighbors.flatten())
                 available_neighbours = set(group_of_old_neighbors) - set(small_cluster_list)
                 if len(available_neighbours) > 0:
                     available_neighbours_list = [value for value in group_of_old_neighbors if
                                                  value in list(available_neighbours)]
                     best_group = max(available_neighbours_list, key=available_neighbours_list.count)
-                    PARC_labels_leiden[single_cell] = best_group
+                    node_communities[single_cell] = best_group
         time_start = time.time()
         while small_community_exists & ((time.time() - time_start) < self.small_community_timeout):
             small_pop_list = []
             small_community_exists = False
-            for cluster in set(list(PARC_labels_leiden.flatten())):
-                population = len(np.where(PARC_labels_leiden == cluster)[0])
+            for cluster in set(list(node_communities.flatten())):
+                population = len(np.where(node_communities == cluster)[0])
                 if population < small_community_size:
                     small_community_exists = True
                     logger.message(f"Cluster {cluster} has small population of {population}.")
-                    small_pop_list.append(np.where(PARC_labels_leiden == cluster)[0])
+                    small_pop_list.append(np.where(node_communities == cluster)[0])
             for small_cluster in small_pop_list:
                 for single_cell in small_cluster:
                     old_neighbors = neighbor_array[single_cell]
-                    group_of_old_neighbors = PARC_labels_leiden[old_neighbors]
+                    group_of_old_neighbors = node_communities[old_neighbors]
                     group_of_old_neighbors = list(group_of_old_neighbors.flatten())
                     best_group = max(set(group_of_old_neighbors), key=group_of_old_neighbors.count)
-                    PARC_labels_leiden[single_cell] = best_group
+                    node_communities[single_cell] = best_group
 
-        PARC_labels_leiden = np.unique(list(PARC_labels_leiden.flatten()), return_inverse=True)[1]
-        PARC_labels_leiden = list(PARC_labels_leiden.flatten())
+        node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]
+        node_communities = list(node_communities.flatten())
         pop_list = []
-        for item in set(PARC_labels_leiden):
-            pop_list.append((item, PARC_labels_leiden.count(item)))
+        for item in set(node_communities):
+            pop_list.append((item, node_communities.count(item)))
         logger.message(f"Cluster labels and populations {len(pop_list)} {pop_list}")
 
-        self.y_data_pred = PARC_labels_leiden
+        self.y_data_pred = node_communities
         return
 
     def accuracy(self, onevsall=1):

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -219,7 +219,7 @@ class PARC:
         graph = ig.Graph(edgelist, edge_attrs={"weight": csr_array.data.tolist()})
         similarities = graph.similarity_jaccard(pairs=edgelist_copy)  # list of jaccard weights
         new_edgelist = []
-        sim_list_array = np.asarray(similarities)
+        similarities_array = np.asarray(similarities)
         if jac_std_factor == "median":
             threshold = np.median(similarities)
         else:
@@ -229,11 +229,11 @@ class PARC:
         logger.message(f"jac std {np.std(similarities):.3f}")
         logger.message(f"jac mean {np.mean(similarities):.3f}")
 
-        strong_locs = np.where(sim_list_array > threshold)[0]
+        strong_locs = np.where(similarities_array > threshold)[0]
         for ii in strong_locs:
             new_edgelist.append(edgelist_copy[ii])
 
-        similarities_new = list(sim_list_array[strong_locs])
+        similarities_new = list(similarities_array[strong_locs])
 
         if jac_weighted_edges:
             graph_pruned = ig.Graph(
@@ -362,16 +362,16 @@ class PARC:
 
         logger.message("Starting global pruning...")
 
-        sim_list_array = np.asarray(similarities)
+        similarities_array = np.asarray(similarities)
         edge_list_copy_array = np.asarray(edgelist_copy)
 
         if jac_std_factor == "median":
             threshold = np.median(similarities)
         else:
             threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
-        strong_locs = np.where(sim_list_array > threshold)[0]
+        strong_locs = np.where(similarities_array > threshold)[0]
         new_edgelist = list(edge_list_copy_array[strong_locs])
-        similarities_new = list(sim_list_array[strong_locs])
+        similarities_new = list(similarities_array[strong_locs])
 
         graph_pruned = ig.Graph(
             n=n_samples,

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -233,13 +233,13 @@ class PARC:
         for ii in strong_locs:
             new_edgelist.append(edgelist_copy[ii])
 
-        sim_list_new = list(sim_list_array[strong_locs])
+        similarities_new = list(sim_list_array[strong_locs])
 
         if jac_weighted_edges:
             graph_pruned = ig.Graph(
                 n=n_samples,
                 edges=list(new_edgelist),
-                edge_attrs={"weight": sim_list_new}
+                edge_attrs={"weight": similarities_new}
             )
         else:
             graph_pruned = ig.Graph(n=n_samples, edges=list(new_edgelist))
@@ -371,12 +371,12 @@ class PARC:
             threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
         strong_locs = np.where(sim_list_array > threshold)[0]
         new_edgelist = list(edge_list_copy_array[strong_locs])
-        sim_list_new = list(sim_list_array[strong_locs])
+        similarities_new = list(sim_list_array[strong_locs])
 
         graph_pruned = ig.Graph(
             n=n_samples,
             edges=list(new_edgelist),
-            edge_attrs={"weight": sim_list_new}
+            edge_attrs={"weight": similarities_new}
         )
         graph_pruned.simplify(combine_edges="sum")  # "first"
         logger.message("Starting Leiden community detection...")

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -452,12 +452,13 @@ class PARC:
             node_communities = np.unique(
                 list(node_communities.flatten()), return_inverse=True
             )[1]
-            logger.message(f"New set of labels {set(node_communities)}")
+
             too_big = False
-            set_PARC_labels_leiden = set(node_communities)
+            set_node_communities = set(node_communities)
+            logger.message(f"New set of labels {set_node_communities}")
 
             node_communities = np.asarray(node_communities)
-            for cluster_ii in set_PARC_labels_leiden:
+            for cluster_ii in set_node_communities:
                 cluster_ii_loc = np.where(node_communities == cluster_ii)[0]
                 pop_ii = len(cluster_ii_loc)
                 not_yet_expanded = pop_ii not in list_pop_too_bigs

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -469,12 +469,12 @@ class PARC:
                     )
                     large_community_indices = community_indices
                     large_community_id = community_id
-                    big_pop = community_size
+                    large_community_size = community_size
             if too_big:
-                list_pop_too_bigs.append(big_pop)
+                list_pop_too_bigs.append(large_community_size)
                 logger.message(
-                    f"Cluster {large_community_id} is too big and has population {big_pop}."
-                    "It will be expanded."
+                    f"Cluster {large_community_id} is too big and has population "
+                    f"{large_community_size}. It will be expanded."
                 )
         node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]
         small_pop_list = []

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -218,7 +218,7 @@ class PARC:
         edges_copy = edges.copy()
         graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
         similarities = graph.similarity_jaccard(pairs=edges_copy)  # list of jaccard weights
-        new_edgelist = []
+        new_edges = []
         similarities_array = np.asarray(similarities)
         if jac_std_factor == "median":
             threshold = np.median(similarities)
@@ -231,18 +231,18 @@ class PARC:
 
         strong_locs = np.where(similarities_array > threshold)[0]
         for ii in strong_locs:
-            new_edgelist.append(edges_copy[ii])
+            new_edges.append(edges_copy[ii])
 
         similarities_new = list(similarities_array[strong_locs])
 
         if jac_weighted_edges:
             graph_pruned = ig.Graph(
                 n=n_samples,
-                edges=list(new_edgelist),
+                edges=list(new_edges),
                 edge_attrs={"weight": similarities_new}
             )
         else:
-            graph_pruned = ig.Graph(n=n_samples, edges=list(new_edgelist))
+            graph_pruned = ig.Graph(n=n_samples, edges=list(new_edges))
         graph_pruned.simplify(combine_edges="sum")
         if jac_weighted_edges:
             if self.partition_type == "ModularityVP":
@@ -370,12 +370,12 @@ class PARC:
         else:
             threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
         strong_locs = np.where(similarities_array > threshold)[0]
-        new_edgelist = list(edge_list_copy_array[strong_locs])
+        new_edges = list(edge_list_copy_array[strong_locs])
         similarities_new = list(similarities_array[strong_locs])
 
         graph_pruned = ig.Graph(
             n=n_samples,
-            edges=list(new_edgelist),
+            edges=list(new_edges),
             edge_attrs={"weight": similarities_new}
         )
         graph_pruned.simplify(combine_edges="sum")  # "first"

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -27,7 +27,7 @@ class PARC:
         knn=30,
         n_iter_leiden=5,
         random_seed=42,
-        num_threads=-1,
+        n_threads=-1,
         distance="l2",
         time_smallpop=15,
         partition_type="ModularityVP",
@@ -56,7 +56,7 @@ class PARC:
         self.knn = knn
         self.n_iter_leiden = n_iter_leiden #the default is 5 in PARC
         self.random_seed = random_seed  # enable reproducible Leiden clustering
-        self.num_threads = num_threads  # number of threads used in KNN search/construction
+        self.n_threads = n_threads  # number of threads used in KNN search/construction
         self.distance = distance  # Euclidean distance "l2" by default; other options "ip" and "cosine"
         self.time_smallpop = time_smallpop #number of seconds trying to check an outlier
         self.partition_type = partition_type #default is the simple ModularityVertexPartition where resolution_parameter =1. In order to change resolution_parameter, we switch to RBConfigurationVP
@@ -75,7 +75,7 @@ class PARC:
             num_dims = self.x_data.shape[1]
             n_elements = self.x_data.shape[0]
             p = hnswlib.Index(space=self.distance, dim=num_dims)  # default to Euclidean distance
-            p.set_num_threads(self.num_threads)  # set threads used in KNN construction
+            p.set_num_threads(self.n_threads)  # set threads used in KNN construction
             if n_elements < 10000:
                 ef_query = min(n_elements - 10, 500)
                 ef_construction = ef_query

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -436,18 +436,18 @@ class PARC:
         while too_big:
 
             X_data_big = x_data[cluster_big_loc, :]
-            PARC_labels_leiden_big = self.run_toobig_subPARC(X_data_big)
-            PARC_labels_leiden_big = PARC_labels_leiden_big + 100000
+            node_communities_big = self.run_toobig_subPARC(X_data_big)
+            node_communities_big = node_communities_big + 100000
             pop_list = []
 
-            for item in set(list(PARC_labels_leiden_big.flatten())):
-                pop_list.append([item, list(PARC_labels_leiden_big.flatten()).count(item)])
+            for item in set(list(node_communities_big.flatten())):
+                pop_list.append([item, list(node_communities_big.flatten()).count(item)])
 
             logger.message(f"pop of big clusters {pop_list}")
             jj = 0
             logger.message(f"shape node_communities {node_communities.shape}")
             for j in cluster_big_loc:
-                node_communities[j] = PARC_labels_leiden_big[jj]
+                node_communities[j] = node_communities_big[jj]
                 jj = jj + 1
             node_communities = np.unique(
                 list(node_communities.flatten()), return_inverse=True

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -306,9 +306,9 @@ class PARC:
                     best_group = max(available_neighbours_list, key=available_neighbours_list.count)
                     PARC_labels_leiden[single_cell] = best_group
 
-        time_smallpop_start = time.time()
+        time_start = time.time()
         logger.message("Handling fragments...")
-        while small_pop_exist & (time.time() - time_smallpop_start < self.small_community_timeout):
+        while small_pop_exist & (time.time() - time_start < self.small_community_timeout):
             small_pop_list = []
             small_pop_exist = False
             for cluster in set(list(PARC_labels_leiden.flatten())):
@@ -500,8 +500,8 @@ class PARC:
                                                  value in list(available_neighbours)]
                     best_group = max(available_neighbours_list, key=available_neighbours_list.count)
                     PARC_labels_leiden[single_cell] = best_group
-        time_smallpop_start = time.time()
-        while small_pop_exist & ((time.time() - time_smallpop_start) < self.small_community_timeout):
+        time_start = time.time()
+        while small_pop_exist & ((time.time() - time_start) < self.small_community_timeout):
             small_pop_list = []
             small_pop_exist = False
             for cluster in set(list(PARC_labels_leiden.flatten())):

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -29,7 +29,7 @@ class PARC:
         random_seed=42,
         n_threads=-1,
         distance="l2",
-        time_smallpop=15,
+        small_community_timeout=15,
         partition_type="ModularityVP",
         resolution_parameter=1.0,
         knn_struct=None,
@@ -58,7 +58,7 @@ class PARC:
         self.random_seed = random_seed  # enable reproducible Leiden clustering
         self.n_threads = n_threads  # number of threads used in KNN search/construction
         self.distance = distance  # Euclidean distance "l2" by default; other options "ip" and "cosine"
-        self.time_smallpop = time_smallpop #number of seconds trying to check an outlier
+        self.small_community_timeout = small_community_timeout #number of seconds trying to check an outlier
         self.partition_type = partition_type #default is the simple ModularityVertexPartition where resolution_parameter =1. In order to change resolution_parameter, we switch to RBConfigurationVP
         self.resolution_parameter = resolution_parameter # defaults to 1. expose this parameter in leidenalg
         self.knn_struct = knn_struct #the hnsw index of the KNN graph on which we perform queries
@@ -308,7 +308,7 @@ class PARC:
 
         time_smallpop_start = time.time()
         logger.message("Handling fragments...")
-        while small_pop_exist & (time.time() - time_smallpop_start < self.time_smallpop):
+        while small_pop_exist & (time.time() - time_smallpop_start < self.small_community_timeout):
             small_pop_list = []
             small_pop_exist = False
             for cluster in set(list(PARC_labels_leiden.flatten())):
@@ -501,7 +501,7 @@ class PARC:
                     best_group = max(available_neighbours_list, key=available_neighbours_list.count)
                     PARC_labels_leiden[single_cell] = best_group
         time_smallpop_start = time.time()
-        while small_pop_exist & ((time.time() - time_smallpop_start) < self.time_smallpop):
+        while small_pop_exist & ((time.time() - time_smallpop_start) < self.small_community_timeout):
             small_pop_list = []
             small_pop_exist = False
             for cluster in set(list(PARC_labels_leiden.flatten())):

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -530,13 +530,13 @@ class PARC:
         self.y_data_pred = node_communities
         return
 
-    def accuracy(self, onevsall=1):
+    def accuracy(self, target=1):
 
         y_data_true = self.y_data_true
         Index_dict = {}
         y_data_pred = self.y_data_pred
         n_samples = len(y_data_pred)
-        n_target = list(y_data_true).count(onevsall)
+        n_target = list(y_data_true).count(target)
         n_pbmc = n_samples - n_target
 
         for k in range(n_samples):
@@ -551,22 +551,22 @@ class PARC:
         for kk in sorted_keys:
             vals = [t for t in Index_dict[kk]]
             majority_val = get_mode(vals)
-            if majority_val == onevsall:
-                logger.message(f"Cluster {kk} has majority {onevsall} with population {len(vals)}")
+            if majority_val == target:
+                logger.message(f"Cluster {kk} has majority {target} with population {len(vals)}")
             if kk == -1:
                 len_unknown = len(vals)
                 logger.message(f"len unknown: {len_unknown}")
-            if (majority_val == onevsall) and (kk != -1):
+            if (majority_val == target) and (kk != -1):
                 positive_labels.append(kk)
-                fp = fp + len([e for e in vals if e != onevsall])
-                tp = tp + len([e for e in vals if e == onevsall])
+                fp = fp + len([e for e in vals if e != target])
+                tp = tp + len([e for e in vals if e == target])
                 list_error = [e for e in vals if e != majority_val]
                 e_count = len(list_error)
                 error_count.append(e_count)
-            elif (majority_val != onevsall) and (kk != -1):
+            elif (majority_val != target) and (kk != -1):
                 negative_labels.append(kk)
-                tn = tn + len([e for e in vals if e != onevsall])
-                fn = fn + len([e for e in vals if e == onevsall])
+                tn = tn + len([e for e in vals if e != target])
+                fn = fn + len([e for e in vals if e == target])
                 error_count.append(len([e for e in vals if e != majority_val]))
 
         predict_class_array = np.array(y_data_pred)
@@ -632,18 +632,18 @@ class PARC:
         if len(targets) > 1:
             f1_accumulated = 0
             f1_acc_noweighting = 0
-            for onevsall_val in targets:
-                logger.message(f"Target is {onevsall_val}")
+            for target in targets:
+                logger.message(f"Target is {target}")
                 vals_roc, predict_class_array, majority_truth_labels, numclusters_targetval = \
-                    self.accuracy(onevsall=onevsall_val)
+                    self.accuracy(target=target)
                 f1_current = vals_roc[1]
-                logger.message(f"Target {onevsall_val} has f1-score of {(f1_current * 100):.2f}")
+                logger.message(f"Target {target} has f1-score of {(f1_current * 100):.2f}")
                 f1_accumulated = f1_accumulated + \
-                    f1_current * (list(self.y_data_true).count(onevsall_val)) / n_samples
+                    f1_current * (list(self.y_data_true).count(target)) / n_samples
                 f1_acc_noweighting = f1_acc_noweighting + f1_current
 
                 list_roc.append(
-                    [self.jac_std_factor, self.l2_std_factor, onevsall_val] +
+                    [self.jac_std_factor, self.l2_std_factor, target] +
                     vals_roc +
                     [numclusters_targetval] +
                     [run_time]

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -236,19 +236,19 @@ class PARC:
         sim_list_new = list(sim_list_array[strong_locs])
 
         if jac_weighted_edges:
-            G_sim = ig.Graph(
+            graph_pruned = ig.Graph(
                 n=n_samples,
                 edges=list(new_edgelist),
                 edge_attrs={"weight": sim_list_new}
             )
         else:
-            G_sim = ig.Graph(n=n_samples, edges=list(new_edgelist))
-        G_sim.simplify(combine_edges="sum")
+            graph_pruned = ig.Graph(n=n_samples, edges=list(new_edgelist))
+        graph_pruned.simplify(combine_edges="sum")
         if jac_weighted_edges:
             if self.partition_type == "ModularityVP":
                 logger.message("partition type MVP")
                 partition = leidenalg.find_partition(
-                    G_sim, leidenalg.ModularityVertexPartition,
+                    graph_pruned, leidenalg.ModularityVertexPartition,
                     weights="weight",
                     n_iterations=self.n_iter_leiden,
                     seed=self.random_seed
@@ -256,7 +256,7 @@ class PARC:
             else:
                 logger.message("partition type RBC")
                 partition = leidenalg.find_partition(
-                    G_sim,
+                    graph_pruned,
                     leidenalg.RBConfigurationVertexPartition,
                     weights="weight",
                     n_iterations=self.n_iter_leiden,
@@ -267,7 +267,7 @@ class PARC:
             if self.partition_type == "ModularityVP":
                 logger.message("partition type MVP")
                 partition = leidenalg.find_partition(
-                    G_sim,
+                    graph_pruned,
                     leidenalg.ModularityVertexPartition,
                     n_iterations=self.n_iter_leiden,
                     seed=self.random_seed
@@ -275,7 +275,7 @@ class PARC:
             else:
                 logger.message("partition type RBC")
                 partition = leidenalg.find_partition(
-                    G_sim,
+                    graph_pruned,
                     leidenalg.RBConfigurationVertexPartition,
                     n_iterations=self.n_iter_leiden,
                     seed=self.random_seed,
@@ -373,18 +373,18 @@ class PARC:
         new_edgelist = list(edge_list_copy_array[strong_locs])
         sim_list_new = list(sim_list_array[strong_locs])
 
-        G_sim = ig.Graph(
+        graph_pruned = ig.Graph(
             n=n_samples,
             edges=list(new_edgelist),
             edge_attrs={"weight": sim_list_new}
         )
-        G_sim.simplify(combine_edges="sum")  # "first"
+        graph_pruned.simplify(combine_edges="sum")  # "first"
         logger.message("Starting Leiden community detection...")
         if jac_weighted_edges:
             if self.partition_type == "ModularityVP":
                 logger.message("partition type MVP")
                 partition = leidenalg.find_partition(
-                    G_sim,
+                    graph_pruned,
                     leidenalg.ModularityVertexPartition,
                     weights="weight",
                     n_iterations=self.n_iter_leiden,
@@ -393,7 +393,7 @@ class PARC:
             else:
                 logger.message("partition type RBC")
                 partition = leidenalg.find_partition(
-                    G_sim,
+                    graph_pruned,
                     leidenalg.RBConfigurationVertexPartition,
                     weights="weight",
                     n_iterations=self.n_iter_leiden,
@@ -405,7 +405,7 @@ class PARC:
             if self.partition_type == "ModularityVP":
                 logger.message("partition type MVP")
                 partition = leidenalg.find_partition(
-                    G_sim,
+                    graph_pruned,
                     leidenalg.ModularityVertexPartition,
                     n_iterations=self.n_iter_leiden,
                     seed=self.random_seed
@@ -413,7 +413,7 @@ class PARC:
             else:
                 logger.message("partition type RBC")
                 partition = leidenalg.find_partition(
-                    G_sim,
+                    graph_pruned,
                     leidenalg.RBConfigurationVertexPartition,
                     n_iterations=self.n_iter_leiden,
                     seed=self.random_seed,

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -215,9 +215,9 @@ class PARC:
         sources, targets = csr_array.nonzero()
 
         edges = list(zip(sources.tolist(), targets.tolist()))
-        edgelist_copy = edges.copy()
+        edges_copy = edges.copy()
         graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
-        similarities = graph.similarity_jaccard(pairs=edgelist_copy)  # list of jaccard weights
+        similarities = graph.similarity_jaccard(pairs=edges_copy)  # list of jaccard weights
         new_edgelist = []
         similarities_array = np.asarray(similarities)
         if jac_std_factor == "median":
@@ -231,7 +231,7 @@ class PARC:
 
         strong_locs = np.where(similarities_array > threshold)[0]
         for ii in strong_locs:
-            new_edgelist.append(edgelist_copy[ii])
+            new_edgelist.append(edges_copy[ii])
 
         similarities_new = list(similarities_array[strong_locs])
 
@@ -355,15 +355,15 @@ class PARC:
 
         edges = list(zip(sources, targets))
 
-        edgelist_copy = edges.copy()
+        edges_copy = edges.copy()
 
         graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
-        similarities = graph.similarity_jaccard(pairs=edgelist_copy)
+        similarities = graph.similarity_jaccard(pairs=edges_copy)
 
         logger.message("Starting global pruning...")
 
         similarities_array = np.asarray(similarities)
-        edge_list_copy_array = np.asarray(edgelist_copy)
+        edge_list_copy_array = np.asarray(edges_copy)
 
         if jac_std_factor == "median":
             threshold = np.median(similarities)

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -229,11 +229,11 @@ class PARC:
         logger.message(f"jac std {np.std(similarities):.3f}")
         logger.message(f"jac mean {np.mean(similarities):.3f}")
 
-        strong_locs = np.where(similarities_array > threshold)[0]
-        for ii in strong_locs:
+        indices_similar = np.where(similarities_array > threshold)[0]
+        for ii in indices_similar:
             new_edges.append(edges_copy[ii])
 
-        similarities_new = list(similarities_array[strong_locs])
+        similarities_new = list(similarities_array[indices_similar])
 
         if jac_weighted_edges:
             graph_pruned = ig.Graph(
@@ -368,9 +368,9 @@ class PARC:
             threshold = np.median(similarities)
         else:
             threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
-        strong_locs = np.where(similarities_array > threshold)[0]
-        new_edges = list(np.asarray(edges_copy)[strong_locs])
-        similarities_new = list(similarities_array[strong_locs])
+        indices_similar = np.where(similarities_array > threshold)[0]
+        new_edges = list(np.asarray(edges_copy)[indices_similar])
+        similarities_new = list(similarities_array[indices_similar])
 
         graph_pruned = ig.Graph(
             n=n_samples,

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -430,12 +430,12 @@ class PARC:
         community_size = len(community_indices)
         if community_size > large_community_factor * n_samples:  # 0.4
             too_big = True
-            cluster_big_loc = community_indices
+            large_community_indices = community_indices
             list_pop_too_bigs = [community_size]
 
         while too_big:
 
-            X_data_big = x_data[cluster_big_loc, :]
+            X_data_big = x_data[large_community_indices, :]
             node_communities_big = self.run_toobig_subPARC(X_data_big)
             node_communities_big = node_communities_big + 100000
             pop_list = []
@@ -446,7 +446,7 @@ class PARC:
             logger.message(f"pop of big clusters {pop_list}")
             jj = 0
             logger.message(f"shape node_communities {node_communities.shape}")
-            for j in cluster_big_loc:
+            for j in large_community_indices:
                 node_communities[j] = node_communities_big[jj]
                 jj = jj + 1
             node_communities = np.unique(
@@ -467,7 +467,7 @@ class PARC:
                     logger.message(
                         f"Cluster {community_id} is too big and has population {community_size}."
                     )
-                    cluster_big_loc = community_indices
+                    large_community_indices = community_indices
                     cluster_big = community_id
                     big_pop = community_size
             if too_big:

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -22,7 +22,7 @@ class PARC:
         jac_std_global="median",
         keep_all_local_dist="auto",
         too_big_factor=0.4,
-        small_pop=10,
+        small_community_size=10,
         jac_weighted_edges=True,
         knn=30,
         n_iter_leiden=5,
@@ -51,7 +51,7 @@ class PARC:
         self.jac_std_global = jac_std_global  #0.15 is also a recommended value performing empirically similar to "median". Generally values between 0-1.5 are reasonable.
         self.keep_all_local_dist = keep_all_local_dist #decides whether or not to do local pruning. default is "auto" which omits LOCAL pruning for samples >300,000 cells.
         self.too_big_factor = too_big_factor  #if a cluster exceeds this share of the entire cell population, then the PARC will be run on the large cluster. at 0.4 it does not come into play
-        self.small_pop = small_pop  # smallest cluster population to be considered a community
+        self.small_community_size = small_community_size  # smallest cluster population to be considered a community
         self.jac_weighted_edges = jac_weighted_edges #boolean. whether to partition using weighted graph
         self.knn = knn
         self.n_iter_leiden = n_iter_leiden #the default is 5 in PARC
@@ -289,7 +289,7 @@ class PARC:
         PARC_labels_leiden = np.unique(list(PARC_labels_leiden.flatten()), return_inverse=True)[1]
         for cluster in set(PARC_labels_leiden):
             population = len(np.where(PARC_labels_leiden == cluster)[0])
-            if population < small_pop:
+            if population < small_community_size:
                 small_pop_exist = True
                 small_pop_list.append(list(np.where(PARC_labels_leiden == cluster)[0]))
                 small_cluster_list.append(cluster)
@@ -313,7 +313,7 @@ class PARC:
             small_pop_exist = False
             for cluster in set(list(PARC_labels_leiden.flatten())):
                 population = len(np.where(PARC_labels_leiden == cluster)[0])
-                if population < small_pop:
+                if population < small_community_size:
                     small_pop_exist = True
 
                     small_pop_list.append(np.where(PARC_labels_leiden == cluster)[0])
@@ -333,7 +333,7 @@ class PARC:
 
         x_data = self.x_data
         too_big_factor = self.too_big_factor
-        small_pop = self.small_pop
+        small_community_size = self.small_community_size
         jac_std_global = self.jac_std_global
         jac_weighted_edges = self.jac_weighted_edges
         knn = self.knn
@@ -482,7 +482,7 @@ class PARC:
         for cluster in set(PARC_labels_leiden):
             population = len(np.where(PARC_labels_leiden == cluster)[0])
 
-            if population < small_pop:  # 10
+            if population < small_community_size:  # 10
                 small_pop_exist = True
 
                 small_pop_list.append(list(np.where(PARC_labels_leiden == cluster)[0]))
@@ -506,7 +506,7 @@ class PARC:
             small_pop_exist = False
             for cluster in set(list(PARC_labels_leiden.flatten())):
                 population = len(np.where(PARC_labels_leiden == cluster)[0])
-                if population < small_pop:
+                if population < small_community_size:
                     small_pop_exist = True
                     logger.message(f"Cluster {cluster} has small population of {population}.")
                     small_pop_list.append(np.where(PARC_labels_leiden == cluster)[0])

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -568,12 +568,12 @@ class PARC:
                 error_count.append(len([e for e in vals if e != majority_val]))
 
         predict_class_array = np.array(y_data_pred)
-        PARC_labels_array = np.array(y_data_pred)
+        y_data_pred_array = np.array(y_data_pred)
         number_clusters_for_target = len(thp1_labels)
         for cancer_class in thp1_labels:
-            predict_class_array[PARC_labels_array == cancer_class] = 1
+            predict_class_array[y_data_pred_array == cancer_class] = 1
         for benign_class in pbmc_labels:
-            predict_class_array[PARC_labels_array == benign_class] = 0
+            predict_class_array[y_data_pred_array == benign_class] = 0
         predict_class_array.reshape((predict_class_array.shape[0], -1))
         error_rate = sum(error_count) / N
         n_target = tp + fn

--- a/tests/test_parc.py
+++ b/tests/test_parc.py
@@ -7,7 +7,7 @@ def test_parc_run_umap_hnsw():
     x_data = iris.data
     y_data = iris.target
 
-    parc_model = PARC(x_data, true_label=y_data)
+    parc_model = PARC(x_data, y_data_true=y_data)
     parc_model.run_PARC()
 
     graph = parc_model.knngraph_full()


### PR DESCRIPTION
# Description

In this PR, I have renamed the following variables to be in keeping with Python naming conventions and to be more descriptive:

| original | new | 
| :---         |     :---   |  
data, X_data, X_input | x_data 
true_labels, true_label, y | y_data_true
labels, PARC_labels | y_data_pred
PARC_labels_array | y_data_pred_array
num_threads | n_threads
N, n_cells, n_elements  | n_samples
small_pop | small_community_size
time_small_pop | small_community_timeout
time_smallpop_start | time_start
small_pop_exist | small_community_exists
too_big_factor  | large_community_factor
distance  | distance_metric
dist_std_local  | l2_std_factor
jac_std_global, jac_std_toobig  | jac_std_factor
G  | graph
G_sim | graph_pruned
sim_list  | similarities
sim_list_new | similarities_new
sim_list_array | similarities_array
strong_locs | indices_similar
PARC_labels_leiden | node_communities
set_PARC_labels_leiden | set_node_communities
PARC_labels_leiden_big | node_communities_big
sources | input_nodes
targets | output_nodes
edgelist | edges
edgelist_copy | edges_copy
new_edgelist | new_edges
onevsall_val, onevsall | target
n_cancer | n_target
pbmc_labels | negative_labels
thp1_labels | positive_labels
cluster_i_loc, cluster_ii_loc | community_indices
pop_i, pop_ii | community_size
cluster_ii, cluster_i | community_id
cluster_big_loc | large_community_indices
cluster_big | large_community_id
big_pop | large_community_size

See https://github.com/ShobiStassen/PARC/pull/32.