### PR TITLE
Refactor `prune_local`

### DIFF
--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -314,13 +314,13 @@ class PARC:
                 distances = distance_array[rowi, :]
                 max_distance = np.mean(distances) + self.l2_std_factor * np.std(distances)
                 to_keep = np.where(distances < max_distance)[0]  # 0 * std
-                updated_nn_ind = neighbors[np.ix_(to_keep)]
+                updated_neighbors = neighbors[np.ix_(to_keep)]
                 updated_nn_weights = distances[np.ix_(to_keep)]
 
-                for ik in range(len(updated_nn_ind)):
+                for ik in range(len(updated_neighbors)):
                     if rowi != neighbors[ik]:  # remove self-loops
                         row_list.append(rowi)
-                        col_list.append(updated_nn_ind[ik])
+                        col_list.append(updated_neighbors[ik])
                         dist = np.sqrt(updated_nn_weights[ik])
                         weight_list.append(1/(dist+0.1))
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -274,7 +274,8 @@ class PARC:
     def prune_local(
         self,
         neighbor_array: np.ndarray,
-        distance_array: np.ndarray
+        distance_array: np.ndarray,
+        l2_std_factor: float | None = None
     ) -> csr_matrix:
         """Prune the nearest neighbors array.
 
@@ -294,6 +295,9 @@ class PARC:
 
             distance_array: An array with dimensions ``(n_samples, k)`` listing the
                 distances to each of the k nearest neighbors for each data point.
+            l2_std_factor: The multiplier used in calculating the Euclidean distance threshold
+                for the distance between two nodes during local pruning. If ``None`` (default),
+                then the value is set to the value of ``self.l2_std_factor``.
 
         Returns:
             A compressed sparse row matrix with dimensions ``(n_samples, n_samples)``,
@@ -306,6 +310,11 @@ class PARC:
 
         n_neighbors = neighbor_array.shape[1]
         n_samples = neighbor_array.shape[0]
+
+        if l2_std_factor is None:
+            l2_std_factor = self.l2_std_factor
+        else:
+            self.l2_std_factor = l2_std_factor
 
         if self.do_prune_local:
             logger.message(

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -311,12 +311,12 @@ class PARC:
             )
             distance_array = distance_array + 0.1
             for row in neighbor_array:
-                distlist = distance_array[rowi, :]
+                distances = distance_array[rowi, :]
                 to_keep = np.where(
-                    distlist < np.mean(distlist) + self.l2_std_factor * np.std(distlist)
+                    distances < np.mean(distances) + self.l2_std_factor * np.std(distances)
                 )[0]  # 0 * std
                 updated_nn_ind = row[np.ix_(to_keep)]
-                updated_nn_weights = distlist[np.ix_(to_keep)]
+                updated_nn_weights = distances[np.ix_(to_keep)]
 
                 for ik in range(len(updated_nn_ind)):
                     if rowi != row[ik]:  # remove self-loops

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -302,7 +302,6 @@ class PARC:
 
         n_neighbors = neighbor_array.shape[1]
         n_samples = neighbor_array.shape[0]
-        rowi = 0
 
         if self.do_prune_local:
             logger.message(
@@ -310,21 +309,19 @@ class PARC:
                 f"{self.l2_std_factor} standard deviations above the mean"
             )
             distance_array = distance_array + 0.1
-            for neighbors in neighbor_array:
-                distances = distance_array[rowi, :]
+            for community_id, neighbors in zip(range(n_samples), neighbor_array):
+                distances = distance_array[community_id, :]
                 max_distance = np.mean(distances) + self.l2_std_factor * np.std(distances)
                 to_keep = np.where(distances < max_distance)[0]  # 0 * std
                 updated_neighbors = neighbors[np.ix_(to_keep)]
                 updated_distances = distances[np.ix_(to_keep)]
 
                 for index in range(len(updated_neighbors)):
-                    if rowi != neighbors[index]:  # remove self-loops
-                        row_list.append(rowi)
+                    if community_id != neighbors[index]:  # remove self-loops
+                        row_list.append(community_id)
                         col_list.append(updated_neighbors[index])
                         dist = np.sqrt(updated_distances[index])
                         weight_list.append(1/(dist+0.1))
-
-                rowi = rowi + 1
         else:
             row_list.extend(
                 list(np.transpose(np.ones((n_neighbors, n_samples)) * range(0, n_samples)).flatten())

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -310,15 +310,15 @@ class PARC:
                 f"{self.l2_std_factor} standard deviations above the mean"
             )
             distance_array = distance_array + 0.1
-            for row in neighbor_array:
+            for neighbors in neighbor_array:
                 distances = distance_array[rowi, :]
                 max_distance = np.mean(distances) + self.l2_std_factor * np.std(distances)
                 to_keep = np.where(distances < max_distance)[0]  # 0 * std
-                updated_nn_ind = row[np.ix_(to_keep)]
+                updated_nn_ind = neighbors[np.ix_(to_keep)]
                 updated_nn_weights = distances[np.ix_(to_keep)]
 
                 for ik in range(len(updated_nn_ind)):
-                    if rowi != row[ik]:  # remove self-loops
+                    if rowi != neighbors[ik]:  # remove self-loops
                         row_list.append(rowi)
                         col_list.append(updated_nn_ind[ik])
                         dist = np.sqrt(updated_nn_weights[ik])

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -303,7 +303,7 @@ class PARC:
         n_neighbors = neighbor_array.shape[1]
         n_samples = neighbor_array.shape[0]
         rowi = 0
-        discard_count = 0
+
         if self.do_prune_local:  # locally prune based on (squared) l2 distance
             logger.message(
                 "Starting local pruning based on Euclidean distance metric at "
@@ -317,7 +317,6 @@ class PARC:
                 )[0]  # 0 * std
                 updated_nn_ind = row[np.ix_(to_keep)]
                 updated_nn_weights = distlist[np.ix_(to_keep)]
-                discard_count = discard_count + (n_neighbors - len(to_keep))
 
                 for ik in range(len(updated_nn_ind)):
                     if rowi != row[ik]:  # remove self-loops

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -317,11 +317,11 @@ class PARC:
                 updated_neighbors = neighbors[np.ix_(to_keep)]
                 updated_distances = distances[np.ix_(to_keep)]
 
-                for ik in range(len(updated_neighbors)):
-                    if rowi != neighbors[ik]:  # remove self-loops
+                for index in range(len(updated_neighbors)):
+                    if rowi != neighbors[index]:  # remove self-loops
                         row_list.append(rowi)
-                        col_list.append(updated_neighbors[ik])
-                        dist = np.sqrt(updated_distances[ik])
+                        col_list.append(updated_neighbors[index])
+                        dist = np.sqrt(updated_distances[index])
                         weight_list.append(1/(dist+0.1))
 
                 rowi = rowi + 1

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -312,9 +312,8 @@ class PARC:
             distance_array = distance_array + 0.1
             for row in neighbor_array:
                 distances = distance_array[rowi, :]
-                to_keep = np.where(
-                    distances < np.mean(distances) + self.l2_std_factor * np.std(distances)
-                )[0]  # 0 * std
+                max_distance = np.mean(distances) + self.l2_std_factor * np.std(distances)
+                to_keep = np.where(distances < max_distance)[0]  # 0 * std
                 updated_nn_ind = row[np.ix_(to_keep)]
                 updated_nn_weights = distances[np.ix_(to_keep)]
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -329,11 +329,11 @@ class PARC:
             col_list = neighbor_array.flatten().tolist()
             weight_list = (1. / (distance_array.flatten() + 0.1)).tolist()
 
-        csr_graph = csr_matrix(
+        csr_array = csr_matrix(
             (np.array(weight_list), (np.array(row_list), np.array(col_list))),
             shape=(n_samples, n_samples)
         )
-        return csr_graph
+        return csr_array
 
     def get_leiden_partition(
         self,

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -320,8 +320,8 @@ class PARC:
                     if community_id != neighbors[index]:  # remove self-loops
                         row_list.append(community_id)
                         col_list.append(updated_neighbors[index])
-                        dist = np.sqrt(updated_distances[index])
-                        weight_list.append(1/(dist+0.1))
+                        distance = np.sqrt(updated_distances[index])
+                        weight_list.append(1/(distance+0.1))
         else:
             row_list.extend(
                 list(np.transpose(np.ones((n_neighbors, n_samples)) * range(0, n_samples)).flatten())

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -315,13 +315,13 @@ class PARC:
                 max_distance = np.mean(distances) + self.l2_std_factor * np.std(distances)
                 to_keep = np.where(distances < max_distance)[0]  # 0 * std
                 updated_neighbors = neighbors[np.ix_(to_keep)]
-                updated_nn_weights = distances[np.ix_(to_keep)]
+                updated_distances = distances[np.ix_(to_keep)]
 
                 for ik in range(len(updated_neighbors)):
                     if rowi != neighbors[ik]:  # remove self-loops
                         row_list.append(rowi)
                         col_list.append(updated_neighbors[ik])
-                        dist = np.sqrt(updated_nn_weights[ik])
+                        dist = np.sqrt(updated_distances[ik])
                         weight_list.append(1/(dist+0.1))
 
                 rowi = rowi + 1

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -304,7 +304,7 @@ class PARC:
         n_samples = neighbor_array.shape[0]
         rowi = 0
 
-        if self.do_prune_local:  # locally prune based on (squared) l2 distance
+        if self.do_prune_local:
             logger.message(
                 "Starting local pruning based on Euclidean distance metric at "
                 f"{self.l2_std_factor} standard deviations above the mean"
@@ -326,7 +326,7 @@ class PARC:
                         weight_list.append(1/(dist+0.1))
 
                 rowi = rowi + 1
-        else:  # don't prune based on distance
+        else:
             row_list.extend(
                 list(np.transpose(np.ones((n_neighbors, n_samples)) * range(0, n_samples)).flatten())
             )


### PR DESCRIPTION
# Description

In this PR:

1. Renamed `make_csrmatrix_noselfloop` -> `prune_local`
2. Renamed `keep_all_local_dist` -> `do_prune_local`, with the opposite meaning, i.e. `do_prune_local = True` is the same as `keep_all_local_dist = False`
3. Added docstrings
4. Added `l2_std_factor` as argument
5. Removed unused `discard_count`
6. Added tests for `prune_local`
7. Renamed the following variables:

| original | new | 
| :---         |     :---   |  
distlist | distances
row | neighbors
updated_nn_ind | updated_neighbors
updated_nn_weights | updated_distances
ik | index
rowi | community_id
csr_graph | csr_array
dist | distance
keep_all_local_dist | do_prune_local (opposite)

See https://github.com/ShobiStassen/PARC/pull/37.

> **Note**
> There was a previous PR: https://github.com/ahill187/PARC/pull/5, which was similar to this one. The reason I am re-doing the PR is because the first refactor, PR https://github.com/ahill187/PARC/pull/2, was too large, so I am splitting up that PR and subsequent PRs and merging them into `master` instead of `main`. Then I can create smaller PRs to merge into the original repo at https://github.com/ShobiStassen/PARC.