### PR TITLE
Factor out `prune_global`

### DIFF
--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -420,13 +420,12 @@ class PARC:
         logger.message(f"Creating graph with {len(indices_similar)} edges and {n_samples} nodes...")
 
         new_edges = list(np.asarray(edges_copy)[indices_similar])
-        similarities_new = list(similarities_array[indices_similar])
 
         if jac_weighted_edges:
             graph_pruned = ig.Graph(
                 n=n_samples,
                 edges=list(new_edges),
-                edge_attrs={"weight": similarities_new}
+                edge_attrs={"weight": list(similarities_array[indices_similar])}
             )
         else:
             graph_pruned = ig.Graph(

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -359,6 +359,7 @@ class PARC:
         csr_array: csr_matrix,
         jac_threshold_type: str,
         jac_std_factor: float,
+        jac_weighted_edges: bool,
         n_samples: int
     ) -> ig.Graph:
         """Prune the graph globally based on the Jaccard similarity measure.
@@ -384,6 +385,8 @@ class PARC:
                 empirically similar to ``jac_threshold_type="median"``, which does not use the
                 ``jac_std_factor``. Generally values between 0-1.5 are reasonable. Higher
                 ``jac_std_factor`` means more edges are kept.
+            jac_weighted_edges: Whether to weight the pruned graph. This is always ``True`` for
+                the top-level PARC run, but can be changed when pruning the large communities.
             n_samples: The number of samples in the data.
 
         Returns:
@@ -391,7 +394,7 @@ class PARC:
         """
 
         input_nodes, output_nodes = csr_array.nonzero()
-        edges = list(zip(input_nodes, output_nodes))
+        edges = list(zip(input_nodes.tolist(), output_nodes.tolist()))
         edges_copy = edges.copy()
 
         graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
@@ -406,15 +409,26 @@ class PARC:
         else:
             threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
 
+        logger.info(f"Jaccard threshold: {threshold:.3f}")
+        logger.info(f"Jaccard standard devaition: {np.std(similarities):.3f}")
+        logger.info(f"Jaccard mean: {np.mean(similarities):.3f}")
+
         indices_similar = np.where(similarities_array > threshold)[0]
         new_edges = list(np.asarray(edges_copy)[indices_similar])
         similarities_new = list(similarities_array[indices_similar])
 
-        graph_pruned = ig.Graph(
-            n=n_samples,
-            edges=list(new_edges),
-            edge_attrs={"weight": similarities_new}
-        )
+        if jac_weighted_edges:
+            graph_pruned = ig.Graph(
+                n=n_samples,
+                edges=list(new_edges),
+                edge_attrs={"weight": similarities_new}
+            )
+        else:
+            graph_pruned = ig.Graph(
+                n=n_samples,
+                edges=list(new_edges)
+            )
+
         graph_pruned.simplify(combine_edges="sum")  # "first"
         return graph_pruned
 
@@ -486,38 +500,14 @@ class PARC:
 
         neighbor_array, distance_array = hnsw.knn_query(x_data, k=knnbig)
         csr_array = self.prune_local(neighbor_array, distance_array)
-        input_nodes, output_nodes = csr_array.nonzero()
 
-        edges = list(zip(input_nodes.tolist(), output_nodes.tolist()))
-        edges_copy = edges.copy()
-        graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
-        similarities = graph.similarity_jaccard(pairs=edges_copy)  # list of jaccard weights
-        new_edges = []
-        similarities_array = np.asarray(similarities)
-        if jac_threshold_type == "median":
-            threshold = np.median(similarities)
-        else:
-            threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
-
-        logger.message(f"jac threshold {threshold:.3f}")
-        logger.message(f"jac std {np.std(similarities):.3f}")
-        logger.message(f"jac mean {np.mean(similarities):.3f}")
-
-        indices_similar = np.where(similarities_array > threshold)[0]
-        for ii in indices_similar:
-            new_edges.append(edges_copy[ii])
-
-        similarities_new = list(similarities_array[indices_similar])
-
-        if jac_weighted_edges:
-            graph_pruned = ig.Graph(
-                n=n_samples,
-                edges=list(new_edges),
-                edge_attrs={"weight": similarities_new}
-            )
-        else:
-            graph_pruned = ig.Graph(n=n_samples, edges=list(new_edges))
-        graph_pruned.simplify(combine_edges="sum")
+        graph_pruned = self.prune_global(
+            csr_array=csr_array,
+            jac_threshold_type=jac_threshold_type,
+            jac_std_factor=jac_std_factor,
+            jac_weighted_edges=jac_weighted_edges,
+            n_samples=n_samples
+        )
 
         partition = self.get_leiden_partition(
             graph=graph_pruned,
@@ -604,6 +594,7 @@ class PARC:
             csr_array=csr_array,
             jac_threshold_type=jac_threshold_type,
             jac_std_factor=jac_std_factor,
+            jac_weighted_edges=True,
             n_samples=n_samples
         )
 

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -419,18 +419,16 @@ class PARC:
         )
         logger.message(f"Creating graph with {len(indices_similar)} edges and {n_samples} nodes...")
 
-        new_edges = list(np.asarray(edges_copy)[indices_similar])
-
         if jac_weighted_edges:
             graph_pruned = ig.Graph(
                 n=n_samples,
-                edges=list(new_edges),
+                edges=list(np.asarray(edges_copy)[indices_similar]),
                 edge_attrs={"weight": list(similarities_array[indices_similar])}
             )
         else:
             graph_pruned = ig.Graph(
                 n=n_samples,
-                edges=list(new_edges)
+                edges=list(np.asarray(edges_copy)[indices_similar])
             )
 
         graph_pruned.simplify(combine_edges="sum")  # "first"

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -402,15 +402,14 @@ class PARC:
         logger.info(f"Creating graph with {len(edges)} edges and {n_samples} nodes...")
 
         graph = ig.Graph(edges, edge_attrs={"weight": csr_array.data.tolist()})
-        similarities = graph.similarity_jaccard(pairs=edges_copy)
-        similarities_array = np.asarray(similarities)
+        similarities = np.asarray(graph.similarity_jaccard(pairs=edges_copy))
 
         if jac_threshold_type == "median":
             threshold = np.median(similarities)
         else:
             threshold = np.mean(similarities) - jac_std_factor * np.std(similarities)
 
-        indices_similar = np.where(similarities_array > threshold)[0]
+        indices_similar = np.where(similarities > threshold)[0]
 
         logger.info(
             f"Pruning {len(edges) - len(indices_similar)} edges based on Jaccard similarity "
@@ -423,7 +422,7 @@ class PARC:
             graph_pruned = ig.Graph(
                 n=n_samples,
                 edges=list(np.asarray(edges_copy)[indices_similar]),
-                edge_attrs={"weight": list(similarities_array[indices_similar])}
+                edge_attrs={"weight": list(similarities[indices_similar])}
             )
         else:
             graph_pruned = ig.Graph(

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -369,8 +369,8 @@ class PARC:
         remove any edges from the graph that do not meet a minimum similarity threshold.
 
         Args:
-            csr_array: A sparse matrix with dimensions
-                (n_samples, n_samples), containing the locally-pruned pair-wise distances.
+            csr_array: A sparse matrix with dimensions ``(n_samples, n_samples)``,
+                containing the locally-pruned pair-wise distances.
             jac_threshold_type: One of ``"median"`` or ``"mean"``. Determines how the
                 Jaccard similarity threshold is calculated during global pruning.
             jac_std_factor: The multiplier used in calculating the Jaccard similarity
@@ -386,7 +386,7 @@ class PARC:
                 ``jac_std_factor``. Generally values between 0-1.5 are reasonable. Higher
                 ``jac_std_factor`` means more edges are kept.
             jac_weighted_edges: Whether to weight the pruned graph. This is always ``True`` for
-                the top-level PARC run, but can be changed when pruning the large communities.
+                the top-level ``PARC`` run, but can be changed when pruning the large communities.
             n_samples: The number of samples in the data.
 
         Returns:


### PR DESCRIPTION
# Description

In this PR:

1. Create new function called `prune_global`
2. Factor out code from `run_parc` and `run_toobig_subPARC`
3. Add tests for `prune_global`

See https://github.com/ShobiStassen/PARC/pull/39.

> **Note:**
>  This is basically a duplicate of PR https://github.com/ahill187/PARC/pull/4, except I am merging into `master` and not `main`.