### PR TITLE
Factor out large community expansion

### DIFF
--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -807,7 +807,6 @@ class PARC:
             )[1]
 
             too_big = False
-            node_communities = np.asarray(node_communities)
             for community_id in set(node_communities):
                 community_indices = np.where(node_communities == community_id)[0]
                 community_size = len(community_indices)

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -838,8 +838,6 @@ class PARC:
                     expanded_community_sizes=expanded_community_sizes
                 )
 
-        node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]
-
         logger.message("Starting small community detection...")
         small_pop_list = []
         small_cluster_list = []

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -798,13 +798,10 @@ class PARC:
             )
             node_communities_big = node_communities_big + 100000
 
-            jj = 0
-            for j in large_community_indices:
-                node_communities[j] = node_communities_big[jj]
-                jj = jj + 1
-            node_communities = np.unique(
-                list(node_communities.flatten()), return_inverse=True
-            )[1]
+            for i, index in enumerate(large_community_indices):
+                node_communities[index] = node_communities_big[i]
+ 
+            node_communities = np.unique(node_communities, return_inverse=True)[1]
 
             too_big = False
             for community_id in set(node_communities):

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import hnswlib
 import os
+from typing import Tuple
 import pathlib
 import json
 from scipy.sparse import csr_matrix
@@ -607,6 +608,50 @@ class PARC:
                 resolution_parameter=self.resolution_parameter
             )
         return partition
+    
+    def get_next_large_community(
+        self,
+        large_community_factor: float,
+        node_communities: np.ndarray,
+        expanded_community_sizes: list[int]
+    ) -> Tuple[int, int, np.ndarray] | Tuple[None, None, list[int]]:
+        """Get the next large community to expand.
+        
+        Args:
+            large_community_factor: A factor used to determine if a community is too large.
+                If the community size is greater than ``large_community_factor * n_samples``,
+                then the community is too large and the ``PARC`` algorithm will be run on the single
+                community to split it up. The default value of ``0.4`` ensures that all communities
+                will be less than the cutoff size.
+            node_communities: An array of the predicted output y labels, with dimensions
+                ``(n_samples, 1)``.
+            expanded_community_sizes: A list of the sizes of the expanded communities.
+            
+        Returns:
+            A tuple containing the large community ID, the large community size, and the indices
+            of the large community. If no large community is found, then return ``None`` for all
+            values.
+        """
+
+        large_community_id, large_community_size, large_community_indices = None, None, []
+        n_samples = len(node_communities)
+        for community_id in set(node_communities):
+            community_indices = np.where(node_communities == community_id)[0]
+            community_size = len(community_indices)
+            not_yet_expanded = community_size not in expanded_community_sizes
+            if community_size > large_community_factor * n_samples and not_yet_expanded:
+                logger.message(
+                    f"\nCommunity {community_id} is too large and has size:\n"
+                    f"{community_size} > large_community_factor * n_samples = "
+                    f"{large_community_factor} * {n_samples} = {large_community_factor * n_samples}\n"
+                    f"Starting large community expansion..."
+                )
+                large_community_indices = community_indices
+                large_community_id = community_id
+                large_community_size = community_size
+                break
+        
+        return large_community_id, large_community_size, large_community_indices
 
     def run_toobig_subPARC(
         self,
@@ -762,37 +807,20 @@ class PARC:
             graph=graph_pruned,
             jac_weighted_edges=jac_weighted_edges
         )
-
         node_communities = np.asarray(partition.membership)
-
-        too_big = False
 
         # The 0th cluster is the largest one.
         # So, if cluster 0 is not too big, then the others won't be too big either
-        large_community_id = 0
-        community_indices = np.where(node_communities == large_community_id)[0]
-        community_size = len(community_indices)
-
-        if community_size > large_community_factor * n_samples:
-            logger.message(
-                f"\nCommunity 0 is too large and has size:\n"
-                f"{community_size} > large_community_factor * n_samples = "
-                f"{large_community_factor} * {n_samples} = {large_community_factor * n_samples}\n"
-                f"Starting large community expansion..."
-            )
-            too_big = True
-            large_community_indices = community_indices
-            list_pop_too_bigs = [community_size]
-        else:
-            logger.message(
-                f"\nCommunity 0 is not too large and has size:\n"
-                f"{community_size} <= large_community_factor * n_samples = "
-                f"{large_community_factor} * {n_samples} = {large_community_factor * n_samples}\n"
-                "Skipping large community expansion."
+        expanded_community_sizes=[]
+        large_community_id, large_community_size, large_community_indices = \
+            self.get_next_large_community(
+                large_community_factor=large_community_factor,
+                node_communities=node_communities,
+                expanded_community_sizes=expanded_community_sizes
             )
 
-        while too_big:
-            logger.message(f"Expanding large community {large_community_id}...")
+        while large_community_id is not None:
+            expanded_community_sizes.append(large_community_size)
             node_communities_big = self.run_toobig_subPARC(
                 x_data=x_data[large_community_indices, :]
             )
@@ -800,28 +828,16 @@ class PARC:
 
             for i, index in enumerate(large_community_indices):
                 node_communities[index] = node_communities_big[i]
- 
+
             node_communities = np.unique(node_communities, return_inverse=True)[1]
 
-            too_big = False
-            for community_id in set(node_communities):
-                community_indices = np.where(node_communities == community_id)[0]
-                community_size = len(community_indices)
-                not_yet_expanded = community_size not in list_pop_too_bigs
-                if community_size > large_community_factor * n_samples and not_yet_expanded:
-                    too_big = True
-                    logger.message(
-                        f"Community {community_id} is too big and has population {community_size}."
-                    )
-                    large_community_indices = community_indices
-                    large_community_id = community_id
-                    large_community_size = community_size
-            if too_big:
-                list_pop_too_bigs.append(large_community_size)
-                logger.message(
-                    f"Community {large_community_id} is too big and has population "
-                    f"{large_community_size}. It will be expanded."
+            large_community_id, large_community_size, large_community_indices = \
+                self.get_next_large_community(
+                    large_community_factor=large_community_factor,
+                    node_communities=node_communities,
+                    expanded_community_sizes=expanded_community_sizes
                 )
+
         node_communities = np.unique(list(node_communities.flatten()), return_inverse=True)[1]
 
         logger.message("Starting small community detection...")

--- a/parc/_parc.py
+++ b/parc/_parc.py
@@ -764,7 +764,6 @@ class PARC:
         )
 
         node_communities = np.asarray(partition.membership)
-        node_communities = np.reshape(node_communities, (n_samples, 1))
 
         too_big = False
 

--- a/tests/test_parc.py
+++ b/tests/test_parc.py
@@ -166,6 +166,36 @@ def test_parc_prune_global(
 
 
 @pytest.mark.parametrize(
+    "large_community_factor",
+    [
+        (1.0),
+        (0.5),
+        (0.08)
+    ]
+)
+def test_parc_large_community_expansion(
+    iris_data, large_community_factor
+):
+    x_data = iris_data[0]
+    y_data = iris_data[1]
+    node_communities = np.random.randint(0, 10, x_data.shape[0])
+    parc_model = PARC(x_data=x_data, y_data_true=y_data)
+    node_communities_expanded = parc_model.large_community_expansion(
+        x_data=x_data,
+        node_communities=node_communities.copy(),
+        large_community_factor=large_community_factor,
+    )
+    if large_community_factor == 1.0:
+        assert np.all(node_communities_expanded == node_communities)
+    else:
+        assert len(np.unique(node_communities_expanded)) >= len(np.unique(node_communities))
+        np.testing.assert_array_equal(
+            np.unique(node_communities_expanded),
+            range(len(np.unique(node_communities_expanded)))
+        )
+
+
+@pytest.mark.parametrize(
     (
         "dataset_name, knn, n_iter_leiden, distance_metric, hnsw_param_ef_construction,"
         "l2_std_factor, jac_threshold_type, jac_std_factor, jac_weighted_edges, do_prune_local,"


### PR DESCRIPTION
## Description

In this PR, I have created two new functions, `get_next_large_community` and `large_community_expansion`. The `fit_predict` function, which runs the entire PARC pipeline, is far too long, and needs to be separated into smaller functions for better readability and testability.

### Redundancy

I would like to also note some changes I made to this section:

```python
for community_id in set(node_communities):
    community_indices = np.where(node_communities == community_id)[0]
    community_size = len(community_indices)
    not_yet_expanded = community_size not in list_pop_too_bigs
    if community_size > large_community_factor * n_samples and not_yet_expanded:
        too_big = True
        logger.message(
            f"Community {community_id} is too big and has population {community_size}."
        )
        large_community_indices = community_indices
        large_community_id = community_id
        large_community_size = community_size
if too_big:
    list_pop_too_bigs.append(large_community_size)
    logger.message(
        f"Community {large_community_id} is too big and has population "
        f"{large_community_size}. It will be expanded."
    )
```

If you look at the code, you will see that because there is no `break` call in the `for` loop, it is iterating over every single `community_id`, even after it has identified a large community. This is unnecessary and slows down the code. Furthermore, it has the effect of adding the smallest of the large communities to the queue next. I'm not sure if this was the author's intention? If that was the intention, then it would be faster to iterate over `set(node_communities)` in reverse. I opted for the interpretation that this was an unintended mistake, and so I have added a `break` line to the loop. If the authors would like to clarify their intention with this loop, I can change (or not change) it accordingly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (updated docstrings or README files)
- [ ] Tests (added new tests or modified current test suite)
- [x] Refactoring (changes in the design of the code that don't change the functionality)

## Tests

- [x] `tests/test_parc.py: test_parc_large_community_expansion`

## Linked PRs / Issues

https://github.com/ShobiStassen/PARC/pull/50

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have documented my code with appropriate docstrings
- [x] I have made corresponding changes to the documentation / README files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
